### PR TITLE
Using upstream OTel auto instrumentation and minimize otel_wrapper

### DIFF
--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -23,14 +23,17 @@ variables OpenTelemetry uses, and then initializing OpenTelemetry using the
 `opentelemetry-instrument` auto instrumentation script from the
 `opentelemetry-instrumentation` package.
 
-Additionally, this configuration the user is using packages derived from
-`opentelemetry-instrumentation` and `opentelemetry-sdk` in their implementation.
+Additionally, this configuration assumes the user is using packages conforming
+to the `opentelemetry-instrumentation` and `opentelemetry-sdk` specifications.
+
+DO NOT use this script for anything else besides SETTING ENVIRONMENT VARIABLES.
+The final `execl` command starts a new python process which replaces the current
+one. One environment variables are preserved.
 
 Usage
 -----
-In the configuration of an AWS Lambda function with
-`otel-instrument` at the root level of a Lambda
-Layer:
+In the configuration of an AWS Lambda function with this file at the
+root level of a Lambda Layer:
 
 .. code::
 
@@ -48,13 +51,13 @@ LAMBDA_RUNTIME_DIR = "LAMBDA_RUNTIME_DIR"
 
 # Update the python paths for packages with `sys.path` and `PYTHONPATH`
 
-# - Expect this `otel-instrument` file to be at the Lambda Layer root. Then, we
-#   know where the OpenTelemetry Python packages are and can add them to the
-#   PYTHONPATH.
+# - Expect this file to be at the Lambda Layer root. Then, we know where the
+#   OpenTelemetry Python packages are and can add them to the PYTHONPATH.
+#
+#   See more:
+#   https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
 
-LAMBDA_LAYER_PKGS_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "python")
-)
+LAMBDA_LAYER_PKGS_DIR = os.path.abspath(os.path.join(os.sep, "opt", "python"))
 
 # - Set Lambda Layer python packages in PYTHONPATH so `opentelemetry-instrument`
 #   script can find them (it needs to find `opentelemetry` find the auto
@@ -85,9 +88,11 @@ if LAMBDA_LAYER_PKGS_DIR not in sys.path:
 from opentelemetry.environment_variables import (
     OTEL_PROPAGATORS,
     OTEL_TRACES_EXPORTER,
-    OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
 )
-from opentelemetry.sdk.environment_variables import OTEL_RESOURCE_ATTRIBUTES
+from opentelemetry.sdk.environment_variables import (
+    OTEL_RESOURCE_ATTRIBUTES,
+    OTEL_SERVICE_NAME,
+)
 
 # - Set the default Trace Exporter
 
@@ -95,20 +100,7 @@ environ.setdefault(OTEL_TRACES_EXPORTER, "otlp_proto_grpc_span")
 
 # - Set the service name
 
-service_name_resource_attribute = "service.name"
-if environ.get(OTEL_RESOURCE_ATTRIBUTES) is None:
-    environ[OTEL_RESOURCE_ATTRIBUTES] = "%s=%s" % (
-        service_name_resource_attribute,
-        environ.get(AWS_LAMBDA_FUNCTION_NAME),
-    )
-elif service_name_resource_attribute not in environ.get(
-    OTEL_RESOURCE_ATTRIBUTES
-):
-    environ[OTEL_RESOURCE_ATTRIBUTES] = "%s=%s,%s" % (
-        service_name_resource_attribute,
-        environ.get(AWS_LAMBDA_FUNCTION_NAME),
-        environ.get(OTEL_RESOURCE_ATTRIBUTES),
-    )
+environ.setdefault(OTEL_SERVICE_NAME, environ.get(AWS_LAMBDA_FUNCTION_NAME))
 
 # - Set the Resource Detectors (Resource Attributes)
 #
@@ -126,24 +118,27 @@ lambda_resource_attributes = (
         environ.get("AWS_LAMBDA_FUNCTION_VERSION"),
     )
 )
-environ[OTEL_RESOURCE_ATTRIBUTES] = "%s,%s" % (
-    lambda_resource_attributes,
-    environ.get(OTEL_RESOURCE_ATTRIBUTES),
-)
+
+if OTEL_RESOURCE_ATTRIBUTES not in environ:
+    environ[OTEL_RESOURCE_ATTRIBUTES] = lambda_resource_attributes
+else:
+    environ[OTEL_RESOURCE_ATTRIBUTES] = "%s,%s" % (
+        lambda_resource_attributes,
+        environ.get(OTEL_RESOURCE_ATTRIBUTES),
+    )
 
 # - Set the default propagators
 
 environ.setdefault(OTEL_PROPAGATORS, "tracecontext,b3,xray")
 
-# - Disable Lambda instrumentation because we will instrument when we know it
-#   patch in a way that is visible to the calling AWS Lambda `boostrap.py` file.
-
-environ[OTEL_PYTHON_DISABLED_INSTRUMENTATIONS] = "aws_lambda"
-
-# - Use a wrapper because instrumentations don't last across parent -> child
-#   processes (i.e. using `excel`) if the child process imports packages
-#   using `getattr(module_name, function_name)`. The child will just import an
-#   uninstrumented package if we don't have `otel_wrapper.py`.
+# - Use a wrapper because AWS Lambda's `python3 /var/runtime/bootstrap.py` will
+#   use `imp.load_module` to load the function from the `_HANDLER` environment
+#   variable. This RELOADS the module and REMOVES any instrumentation patching
+#   done earlier. So we delay instrumentation until `boostrap.py` imports
+#   `otel_wrapper.py` at which we know the patching will be picked up.
+#
+#   See more:
+#   https://docs.python.org/3/library/imp.html#imp.load_module
 
 environ["ORIG_HANDLER"] = environ.get("_HANDLER")
 environ["_HANDLER"] = "otel_wrapper.lambda_handler"

--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -1,44 +1,160 @@
 #!/usr/bin/env python3
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
 
-from os import environ, system
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+`otel-instrument`
+
+This script configures and sets up OpenTelemetry Python with the values we
+expect will be used by the common user. It does this by setting the environment
+variables OpenTelemetry uses, and then initializing OpenTelemetry using the
+`opentelemetry-instrument` auto instrumentation script from the
+`opentelemetry-instrumentation` package.
+
+Additionally, this configuration the user is using packages derived from
+`opentelemetry-instrumentation` and `opentelemetry-sdk` in their implementation.
+
+Usage
+-----
+In the configuration of an AWS Lambda function with
+`otel-instrument` at the root level of a Lambda
+Layer:
+
+.. code::
+
+    AWS_LAMBDA_EXEC_WRAPPER = /opt/otel-instrument
+
+"""
+
+import os
 import sys
+from os import environ, execl
 
-# the path to the interpreter and all of the originally intended arguments
-args = sys.argv[1:]
+AWS_LAMBDA_FUNCTION_NAME = "AWS_LAMBDA_FUNCTION_NAME"
+PYTHONPATH = "PYTHONPATH"
+LAMBDA_RUNTIME_DIR = "LAMBDA_RUNTIME_DIR"
 
-# enable OTel wrapper
-environ["ORIG_HANDLER"] = environ.get("_HANDLER")
-environ["_HANDLER"] = "otel_wrapper.lambda_handler"
+# Update the python paths for packages with `sys.path` and `PYTHONPATH`
 
-# config default traces exporter if missing
-environ.setdefault("OTEL_TRACES_EXPORTER", "otlp_proto_grpc_span")
+# - Expect this `otel-instrument` file to be at the Lambda Layer root. Then, we
+#   know where the OpenTelemetry Python packages are and can add them to the
+#   PYTHONPATH.
 
-# set service name
-if environ.get("OTEL_RESOURCE_ATTRIBUTES") is None:
-    environ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=%s" % (
-        environ.get("AWS_LAMBDA_FUNCTION_NAME")
+LAMBDA_LAYER_PKGS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "python")
+)
+
+# - Set Lambda Layer python packages in PYTHONPATH so `opentelemetry-instrument`
+#   script can find them (it needs to find `opentelemetry` find the auto
+#   instrumentation `run()` method)
+
+if PYTHONPATH not in environ:
+    environ[PYTHONPATH] = LAMBDA_LAYER_PKGS_DIR
+elif LAMBDA_LAYER_PKGS_DIR not in environ[PYTHONPATH]:
+    environ[PYTHONPATH] += os.pathsep + LAMBDA_LAYER_PKGS_DIR
+
+# - Set Lambda runtime python packages in PYTHONPATH so
+#   `opentelemetry-instrument` script can find them during auto instrumentation
+#   and instrument them.
+
+if PYTHONPATH not in environ:
+    environ[PYTHONPATH] = os.environ[LAMBDA_RUNTIME_DIR]
+if os.environ[LAMBDA_RUNTIME_DIR] not in environ[PYTHONPATH]:
+    environ[PYTHONPATH] += os.pathsep + os.environ[LAMBDA_RUNTIME_DIR]
+
+# Configure OpenTelemetry Python with environment variables
+
+# - Set Lambda Layer python packages in current python path so we can find them
+#   right away in this script
+
+if LAMBDA_LAYER_PKGS_DIR not in sys.path:
+    sys.path.append(LAMBDA_LAYER_PKGS_DIR)
+
+from opentelemetry.environment_variables import (
+    OTEL_PROPAGATORS,
+    OTEL_TRACES_EXPORTER,
+    OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
+)
+from opentelemetry.sdk.environment_variables import OTEL_RESOURCE_ATTRIBUTES
+
+# - Set the default Trace Exporter
+
+environ.setdefault(OTEL_TRACES_EXPORTER, "otlp_proto_grpc_span")
+
+# - Set the service name
+
+service_name_resource_attribute = "service.name"
+if environ.get(OTEL_RESOURCE_ATTRIBUTES) is None:
+    environ[OTEL_RESOURCE_ATTRIBUTES] = "%s=%s" % (
+        service_name_resource_attribute,
+        environ.get(AWS_LAMBDA_FUNCTION_NAME),
     )
-elif "service.name=" not in environ.get("OTEL_RESOURCE_ATTRIBUTES"):
-    environ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=%s,%s" % (
-        environ.get("AWS_LAMBDA_FUNCTION_NAME"),
-        environ.get("OTEL_RESOURCE_ATTRIBUTES"),
+elif service_name_resource_attribute not in environ.get(
+    OTEL_RESOURCE_ATTRIBUTES
+):
+    environ[OTEL_RESOURCE_ATTRIBUTES] = "%s=%s,%s" % (
+        service_name_resource_attribute,
+        environ.get(AWS_LAMBDA_FUNCTION_NAME),
+        environ.get(OTEL_RESOURCE_ATTRIBUTES),
     )
 
-# TODO: Remove if sdk support resource detector env variable configuration.
+# - Set the Resource Detectors (Resource Attributes)
+#
+#   TODO: waiting on OTel Python support for configuring Resource Detectors from
+#   an environment variable. Replace the bottom code with the following when
+#   this is possible.
+#
+#   environ["OTEL_RESOURCE_DETECTORS"] = "aws_lambda"
+#
 lambda_resource_attributes = (
     "cloud.region=%s,cloud.provider=aws,faas.name=%s,faas.version=%s"
     % (
         environ.get("AWS_REGION"),
-        environ.get("AWS_LAMBDA_FUNCTION_NAME"),
+        environ.get(AWS_LAMBDA_FUNCTION_NAME),
         environ.get("AWS_LAMBDA_FUNCTION_VERSION"),
     )
 )
-environ["OTEL_RESOURCE_ATTRIBUTES"] = "%s,%s" % (
+environ[OTEL_RESOURCE_ATTRIBUTES] = "%s,%s" % (
     lambda_resource_attributes,
-    environ.get("OTEL_RESOURCE_ATTRIBUTES"),
+    environ.get(OTEL_RESOURCE_ATTRIBUTES),
 )
 
-# start the runtime with the extra options
-system(" ".join(args))
+# - Set the default propagators
+
+environ.setdefault(OTEL_PROPAGATORS, "tracecontext,b3,xray")
+
+# - Disable Lambda instrumentation because we will instrument when we know it
+#   patch in a way that is visible to the calling AWS Lambda `boostrap.py` file.
+
+environ[OTEL_PYTHON_DISABLED_INSTRUMENTATIONS] = "aws_lambda"
+
+# - Use a wrapper because instrumentations don't last across parent -> child
+#   processes (i.e. using `excel`) if the child process imports packages
+#   using `getattr(module_name, function_name)`. The child will just import an
+#   uninstrumented package if we don't have `otel_wrapper.py`.
+
+environ["ORIG_HANDLER"] = environ.get("_HANDLER")
+environ["_HANDLER"] = "otel_wrapper.lambda_handler"
+
+# - Call the upstream auto instrumentation script
+
+executable = sys.argv[1]
+
+execl(
+    executable,
+    executable,
+    os.path.join(LAMBDA_LAYER_PKGS_DIR, "bin", "opentelemetry-instrument",),
+    *sys.argv[1:],
+)

--- a/python/src/otel/otel_sdk/otel_wrapper.py
+++ b/python/src/otel/otel_sdk/otel_wrapper.py
@@ -1,101 +1,19 @@
-import logging
 import os
-
 from importlib import import_module
-from pkg_resources import iter_entry_points
 
-from opentelemetry.instrumentation.dependencies import get_dist_dependency_conflicts
 from opentelemetry.instrumentation.aws_lambda import AwsLambdaInstrumentor
-from opentelemetry.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
-from opentelemetry.instrumentation.distro import BaseDistro, DefaultDistro
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
-# TODO: waiting OTel Python supports env variable config for resource detector
-# from opentelemetry.resource import AwsLambdaResourceDetector
-# from opentelemetry.sdk.resources import Resource
-# resource = Resource.create().merge(AwsLambdaResourceDetector().detect())
-# trace.get_tracer_provider.resource = resource
-
-def _load_distros() -> BaseDistro:
-    for entry_point in iter_entry_points("opentelemetry_distro"):
-        try:
-            distro = entry_point.load()()
-            if not isinstance(distro, BaseDistro):
-                logger.debug(
-                    "%s is not an OpenTelemetry Distro. Skipping",
-                    entry_point.name,
-                )
-                continue
-            logger.debug(
-                "Distribution %s will be configured", entry_point.name
-            )
-            return distro
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug("Distribution %s configuration failed", entry_point.name)
-    return DefaultDistro()
-
-def _load_instrumentors(distro):
-    package_to_exclude = os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, [])
-    if isinstance(package_to_exclude, str):
-        package_to_exclude = package_to_exclude.split(",")
-        # to handle users entering "requests , flask" or "requests, flask" with spaces
-        package_to_exclude = [x.strip() for x in package_to_exclude]
-
-    for entry_point in iter_entry_points("opentelemetry_instrumentor"):
-        if entry_point.name in package_to_exclude:
-            logger.debug(
-                "Instrumentation skipped for library %s", entry_point.name
-            )
-            continue
-
-        try:
-            conflict = get_dist_dependency_conflicts(entry_point.dist)
-            if conflict:
-                logger.debug(
-                    "Skipping instrumentation %s: %s",
-                    entry_point.name,
-                    conflict,
-                )
-                continue
-
-            # tell instrumentation to not run dep checks again as we already did it above
-            distro.load_instrumentor(entry_point, skip_dep_check=True)
-            logger.info("Instrumented %s", entry_point.name)
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug("Instrumenting of %s failed", entry_point.name)
-
-def _load_configurators():
-    configured = None
-    for entry_point in iter_entry_points("opentelemetry_configurator"):
-        if configured is not None:
-            logger.warning(
-                "Configuration of %s not loaded, %s already loaded",
-                entry_point.name,
-                configured,
-            )
-            continue
-        try:
-            entry_point.load()().configure()  # type: ignore
-            configured = entry_point.name
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug("Configuration of %s failed", entry_point.name)
+AwsLambdaInstrumentor().instrument()
 
 
 def modify_module_name(module_name):
     """Returns a valid modified module to get imported"""
     return ".".join(module_name.split("/"))
 
+
 class HandlerError(Exception):
     pass
 
-distro = _load_distros()
-distro.configure()
-_load_configurators()
-_load_instrumentors(distro)
-# TODO: move to python-contrib
-AwsLambdaInstrumentor().instrument(skip_dep_check=True)
 
 path = os.environ.get("ORIG_HANDLER", None)
 if path is None:


### PR DESCRIPTION
# Description

@wangzlei and I worked together to figure out how to _mostly_ auto-instrument Lambda functions using the upstream `opentelemetry-instrument` [auto-instrumentation package](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/3049b4bfc5e2b64679f27543c1bd9d220047626e/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation).

We made two major updates

## Update the PYTHONPATH so we can call `opentelemtry-instrument`

The auto-instrumentation package counts on 2 things:
* the `opentelemetry` package
* locating all the python packages the user wants to instrument

Both these 2 things require us modifying the environment variable `PYTHONPATH` right away in `otel-instrument`. AWS Lambda will add the correct paths but it does it too late. (It only does it once it calls it's originally intended entry point of `python3 /var/runtime/bootstrap.py`).

## Update the `otel_wrapper.py` to only call the `AwsLambdaInstrumentor`

All of the instrumentation is done in `sitecustomize.py` by `opentelemetry-instrument`. However, the way the Lambda Handler is imported in the AWS Lambda `bootstrap.py` file which is run after `sitecustomize.py` CLEARS any instrumentation done on `lambda_function.lambda_handler`. That's why we keep `otel_wrapper.py` around. So that `bootstrap.py` can call it, do any destructive imports it needs to do, and then call `AwsLambdaInstrumentor.instrument()` explicitly. This way we _know_ the Lambda function is instrumented, we can import, and give `bootstrap.py` the Lambda Handler that we know is instrumented.

## Future Work

We would ideally like to modify `boostrap.py` or investigate how we can get rid of `otel_wrapper.py` and have all the instrumentation be finished in `sitecustomize.py` such that `bootstrap.py` can just import the normal lambda handler at the `_HANDLER` environment variable without destroying the import at all.

Fixes #152 