### PR TITLE
Lambda exec wrapper calls upstream OTel Python auto instr script

### DIFF
--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -100,13 +100,8 @@ fi
 #
 #   export OTEL_RESOURCE_DETECTORS="aws_lambda";
 #
-export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION";
 
-if [ -z ${OTEL_RESOURCE_ATTRIBUTES} ]; then
-    export OTEL_RESOURCE_ATTRIBUTES=$LAMBDA_RESOURCE_ATTRIBUTES;
-else
-    export OTEL_RESOURCE_ATTRIBUTES="$LAMBDA_RESOURCE_ATTRIBUTES,$OTEL_RESOURCE_ATTRIBUTES";
-fi
+export OTEL_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION,$OTEL_RESOURCE_ATTRIBUTES";
 
 # - Uses the default `OTEL_PROPAGATORS` which is set to `tracecontext,baggage`
 

--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Copyright The OpenTelemetry Authors
 #
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-: '
+: <<'END_DOCUMENTATION'
 `otel-instrument`
 
 This script configures and sets up OpenTelemetry Python with the values we
@@ -43,7 +43,7 @@ root level of a Lambda Layer:
 
     AWS_LAMBDA_EXEC_WRAPPER = /opt/otel-instrument
 
-'
+END_DOCUMENTATION
 
 # Use constants to access the environment variables we want to use in this
 # script.
@@ -68,17 +68,13 @@ root level of a Lambda Layer:
 #   See more:
 #   https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
 
-export LAMBDA_LAYER_PKGS_DIR="/opt/python"
+export LAMBDA_LAYER_PKGS_DIR="/opt/python";
 
 # - Set Lambda Layer python packages in PYTHONPATH so `opentelemetry-instrument`
 #   script can find them (it needs to find `opentelemetry` to find the auto
 #   instrumentation `run()` method later)
 
-if [ -z ${PYTHONPATH} ]; then
-    export PYTHONPATH=$LAMBDA_LAYER_PKGS_DIR;
-else
-    export PYTHONPATH="$LAMBDA_LAYER_PKGS_DIR:$PYTHONPATH";
-fi
+export PYTHONPATH="$LAMBDA_LAYER_PKGS_DIR:$PYTHONPATH";
 
 # - Set Lambda runtime python packages in PYTHONPATH so
 #   `opentelemetry-instrument` script can find them during auto instrumentation
@@ -88,11 +84,7 @@ export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
 
 # Configure OpenTelemetry Python with environment variables
 
-# - Set the default Trace Exporter
-
-if [ -z ${OTEL_TRACES_EXPORTER} ]; then
-    export OTEL_TRACES_EXPORTER="otlp_proto_grpc_span";
-fi
+# - Uses the default `OTEL_TRACES_EXPORTER` which is set to `otlp_proto_grpc`
 
 # - Set the service name
 
@@ -108,7 +100,7 @@ fi
 #
 #   export OTEL_RESOURCE_DETECTORS="aws_lambda";
 #
-export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION"
+export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION";
 
 if [ -z ${OTEL_RESOURCE_ATTRIBUTES} ]; then
     export OTEL_RESOURCE_ATTRIBUTES=$LAMBDA_RESOURCE_ATTRIBUTES;
@@ -116,11 +108,7 @@ else
     export OTEL_RESOURCE_ATTRIBUTES="$LAMBDA_RESOURCE_ATTRIBUTES,$OTEL_RESOURCE_ATTRIBUTES";
 fi
 
-# - Set the default propagators
-
-if [ -z ${OTEL_PROPAGATORS} ]; then
-    export OTEL_PROPAGATORS="tracecontext,b3,xray";
-fi
+# - Uses the default `OTEL_PROPAGATORS` which is set to `tracecontext,baggage`
 
 # - Use a wrapper because AWS Lambda's `python3 /var/runtime/bootstrap.py` will
 #   use `imp.load_module` to load the function from the `_HANDLER` environment
@@ -137,5 +125,3 @@ export _HANDLER="otel_wrapper.lambda_handler";
 # - Call the upstream auto instrumentation script
 
 python3 $LAMBDA_LAYER_PKGS_DIR/bin/opentelemetry-instrument "$@"
-
-

--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -1,44 +1,141 @@
-#!/usr/bin/env python3
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+#!/usr/bin/env bash
 
-from os import environ, system
-import sys
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# the path to the interpreter and all of the originally intended arguments
-args = sys.argv[1:]
+: '
+`otel-instrument`
 
-# enable OTel wrapper
-environ["ORIG_HANDLER"] = environ.get("_HANDLER")
-environ["_HANDLER"] = "otel_wrapper.lambda_handler"
+This script configures and sets up OpenTelemetry Python with the values we
+expect will be used by the common user. It does this by setting the environment
+variables OpenTelemetry uses, and then initializing OpenTelemetry using the
+`opentelemetry-instrument` auto instrumentation script from the
+`opentelemetry-instrumentation` package.
 
-# config default traces exporter if missing
-environ.setdefault("OTEL_TRACES_EXPORTER", "otlp_proto_grpc_span")
+Additionally, this configuration assumes the user is using packages conforming
+to the `opentelemetry-instrumentation` and `opentelemetry-sdk` specifications.
 
-# set service name
-if environ.get("OTEL_RESOURCE_ATTRIBUTES") is None:
-    environ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=%s" % (
-        environ.get("AWS_LAMBDA_FUNCTION_NAME")
-    )
-elif "service.name=" not in environ.get("OTEL_RESOURCE_ATTRIBUTES"):
-    environ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=%s,%s" % (
-        environ.get("AWS_LAMBDA_FUNCTION_NAME"),
-        environ.get("OTEL_RESOURCE_ATTRIBUTES"),
-    )
+DO NOT use this script for anything else besides SETTING ENVIRONMENT VARIABLES.
 
-# TODO: Remove if sdk support resource detector env variable configuration.
-lambda_resource_attributes = (
-    "cloud.region=%s,cloud.provider=aws,faas.name=%s,faas.version=%s"
-    % (
-        environ.get("AWS_REGION"),
-        environ.get("AWS_LAMBDA_FUNCTION_NAME"),
-        environ.get("AWS_LAMBDA_FUNCTION_VERSION"),
-    )
-)
-environ["OTEL_RESOURCE_ATTRIBUTES"] = "%s,%s" % (
-    lambda_resource_attributes,
-    environ.get("OTEL_RESOURCE_ATTRIBUTES"),
-)
+See more:
+https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
 
-# start the runtime with the extra options
-system(" ".join(args))
+Usage
+-----
+We expect this file to be at the root of a Lambda Layer. Having it anywhere else
+seems to mean AWS Lambda cannot find it.
+
+In the configuration of an AWS Lambda function with this file at the
+root level of a Lambda Layer:
+
+.. code::
+
+    AWS_LAMBDA_EXEC_WRAPPER = /opt/otel-instrument
+
+'
+
+# Use constants to access the environment variables we want to use in this
+# script.
+
+# See more:
+# https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
+
+# - Reserved environment variables
+
+# - - $AWS_LAMBDA_FUNCTION_NAME
+# - - $LAMBDA_RUNTIME_DIR
+
+# - Unreserved environment variables
+
+# - - $PYTHONPATH
+
+# Update the python paths for packages with `sys.path` and `PYTHONPATH`
+
+# - We know that the path to the Lambda Layer OpenTelemetry Python packages are
+#   well defined, so we can add them to the PYTHONPATH.
+#
+#   See more:
+#   https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
+
+export LAMBDA_LAYER_PKGS_DIR="/opt/python"
+
+# - Set Lambda Layer python packages in PYTHONPATH so `opentelemetry-instrument`
+#   script can find them (it needs to find `opentelemetry` to find the auto
+#   instrumentation `run()` method later)
+
+if [ -z ${PYTHONPATH} ]; then
+    export PYTHONPATH=$LAMBDA_LAYER_PKGS_DIR;
+else
+    export PYTHONPATH="$LAMBDA_LAYER_PKGS_DIR:$PYTHONPATH";
+fi
+
+# - Set Lambda runtime python packages in PYTHONPATH so
+#   `opentelemetry-instrument` script can find them during auto instrumentation
+#   and instrument them.
+
+export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
+
+# Configure OpenTelemetry Python with environment variables
+
+# - Set the default Trace Exporter
+
+if [ -z ${OTEL_TRACES_EXPORTER} ]; then
+    export OTEL_TRACES_EXPORTER="otlp_proto_grpc_span";
+fi
+
+# - Set the service name
+
+if [ -z ${OTEL_SERVICE_NAME} ]; then
+    export OTEL_SERVICE_NAME=$AWS_LAMBDA_FUNCTION_NAME;
+fi
+
+# - Set the Resource Detectors (Resource Attributes)
+#
+#   TODO: waiting on OTel Python support for configuring Resource Detectors from
+#   an environment variable. Replace the bottom code with the following when
+#   this is possible.
+#
+#   export OTEL_RESOURCE_DETECTORS="aws_lambda";
+#
+export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION"
+
+if [ -z ${OTEL_RESOURCE_ATTRIBUTES} ]; then
+    export OTEL_RESOURCE_ATTRIBUTES=$LAMBDA_RESOURCE_ATTRIBUTES;
+else
+    export OTEL_RESOURCE_ATTRIBUTES="$LAMBDA_RESOURCE_ATTRIBUTES,$OTEL_RESOURCE_ATTRIBUTES";
+fi
+
+# - Set the default propagators
+
+if [ -z ${OTEL_PROPAGATORS} ]; then
+    export OTEL_PROPAGATORS="tracecontext,b3,xray";
+fi
+
+# - Use a wrapper because AWS Lambda's `python3 /var/runtime/bootstrap.py` will
+#   use `imp.load_module` to load the function from the `_HANDLER` environment
+#   variable. This RELOADS the module and REMOVES any instrumentation patching
+#   done earlier. So we delay instrumentation until `boostrap.py` imports
+#   `otel_wrapper.py` at which we know the patching will be picked up.
+#
+#   See more:
+#   https://docs.python.org/3/library/imp.html#imp.load_module
+
+export ORIG_HANDLER=$_HANDLER;
+export _HANDLER="otel_wrapper.lambda_handler";
+
+# - Call the upstream auto instrumentation script
+
+python3 $LAMBDA_LAYER_PKGS_DIR/bin/opentelemetry-instrument "$@"
+
+

--- a/python/src/otel/otel_sdk/otel_wrapper.py
+++ b/python/src/otel/otel_sdk/otel_wrapper.py
@@ -51,14 +51,16 @@ class HandlerError(Exception):
 
 AwsLambdaInstrumentor().instrument()
 
-path = os.environ.get("ORIG_HANDLER", None)
+path = os.environ.get("ORIG_HANDLER")
+
 if path is None:
     raise HandlerError("ORIG_HANDLER is not defined.")
-parts = path.rsplit(".", 1)
-if len(parts) != 2:
-    raise HandlerError("Value %s for ORIG_HANDLER has invalid format." % path)
 
-(mod_name, handler_name) = parts
+try:
+    (mod_name, handler_name) = path.rsplit(".", 1)
+except ValueError as e:
+    raise HandlerError("Bad path '{}' for ORIG_HANDLER: {}".format(path, str(e)))
+
 modified_mod_name = modify_module_name(mod_name)
 handler_module = import_module(modified_mod_name)
 lambda_handler = getattr(handler_module, handler_name)

--- a/python/src/otel/otel_sdk/otel_wrapper.py
+++ b/python/src/otel/otel_sdk/otel_wrapper.py
@@ -1,101 +1,55 @@
-import logging
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+`otel_wrapper.py`
+
+This file serves as a wrapper over the user's Lambda function.
+
+Usage
+-----
+Patch the reserved `_HANDLER` Lambda environment variable to point to this
+file's `otel_wrapper.lambda_handler` property. Do this having saved the original
+`_HANDLER` in the `ORIG_HANDLER` environment variable. Doing this makes it so
+that **on import of this file, the handler is instrumented**.
+
+Instrumenting any earlier will cause the instrumentation to be lost because the
+AWS Service uses `imp.load_module` to import the handler which RELOADS the
+module. This is why AwsLambdaInstrumentor cannot be instrumented with the
+`opentelemetry-instrument` script.
+
+See more:
+https://docs.python.org/3/library/imp.html#imp.load_module
+
+"""
+
 import os
-
 from importlib import import_module
-from pkg_resources import iter_entry_points
 
-from opentelemetry.instrumentation.dependencies import get_dist_dependency_conflicts
 from opentelemetry.instrumentation.aws_lambda import AwsLambdaInstrumentor
-from opentelemetry.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
-from opentelemetry.instrumentation.distro import BaseDistro, DefaultDistro
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
-# TODO: waiting OTel Python supports env variable config for resource detector
-# from opentelemetry.resource import AwsLambdaResourceDetector
-# from opentelemetry.sdk.resources import Resource
-# resource = Resource.create().merge(AwsLambdaResourceDetector().detect())
-# trace.get_tracer_provider.resource = resource
-
-def _load_distros() -> BaseDistro:
-    for entry_point in iter_entry_points("opentelemetry_distro"):
-        try:
-            distro = entry_point.load()()
-            if not isinstance(distro, BaseDistro):
-                logger.debug(
-                    "%s is not an OpenTelemetry Distro. Skipping",
-                    entry_point.name,
-                )
-                continue
-            logger.debug(
-                "Distribution %s will be configured", entry_point.name
-            )
-            return distro
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug("Distribution %s configuration failed", entry_point.name)
-    return DefaultDistro()
-
-def _load_instrumentors(distro):
-    package_to_exclude = os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, [])
-    if isinstance(package_to_exclude, str):
-        package_to_exclude = package_to_exclude.split(",")
-        # to handle users entering "requests , flask" or "requests, flask" with spaces
-        package_to_exclude = [x.strip() for x in package_to_exclude]
-
-    for entry_point in iter_entry_points("opentelemetry_instrumentor"):
-        if entry_point.name in package_to_exclude:
-            logger.debug(
-                "Instrumentation skipped for library %s", entry_point.name
-            )
-            continue
-
-        try:
-            conflict = get_dist_dependency_conflicts(entry_point.dist)
-            if conflict:
-                logger.debug(
-                    "Skipping instrumentation %s: %s",
-                    entry_point.name,
-                    conflict,
-                )
-                continue
-
-            # tell instrumentation to not run dep checks again as we already did it above
-            distro.load_instrumentor(entry_point, skip_dep_check=True)
-            logger.info("Instrumented %s", entry_point.name)
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug("Instrumenting of %s failed", entry_point.name)
-
-def _load_configurators():
-    configured = None
-    for entry_point in iter_entry_points("opentelemetry_configurator"):
-        if configured is not None:
-            logger.warning(
-                "Configuration of %s not loaded, %s already loaded",
-                entry_point.name,
-                configured,
-            )
-            continue
-        try:
-            entry_point.load()().configure()  # type: ignore
-            configured = entry_point.name
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug("Configuration of %s failed", entry_point.name)
 
 
 def modify_module_name(module_name):
     """Returns a valid modified module to get imported"""
     return ".".join(module_name.split("/"))
 
+
 class HandlerError(Exception):
     pass
 
-distro = _load_distros()
-distro.configure()
-_load_configurators()
-_load_instrumentors(distro)
-# TODO: move to python-contrib
-AwsLambdaInstrumentor().instrument(skip_dep_check=True)
+
+AwsLambdaInstrumentor().instrument()
 
 path = os.environ.get("ORIG_HANDLER", None)
 if path is None:

--- a/python/src/otel/setup.cfg
+++ b/python/src/otel/setup.cfg
@@ -50,5 +50,7 @@ test =
 where = otel_sdk
 
 [options.entry_points]
-opentelemetry_instrumentor =
-    aws_lambda = opentelemetry.instrumentation.aws_lambda:AwsLambdaInstrumentor
+# NOTE: (NathanielRN) DO NOT add AwsLambdaInstrumentor entry point because
+# current AWS Lambda implementation reloads a fresh import of the user's Lambda
+# handler. Auto Instrumentation runs _before_ and if it instruments the handler
+# that patching will be lost.

--- a/python/src/tox.ini
+++ b/python/src/tox.ini
@@ -14,7 +14,6 @@ passenv = TOXENV
 
 setenv =
     OTEL_PYTHON_TRACER_PROVIDER=sdk_tracer_provider
-    OTEL_TRACES_EXPORTER="console_span"
     ; override CORE_REPO_SHA via env variable when testing other branches/commits than main
     ; i.e: CORE_REPO_SHA=dde62cebffe519c35875af6d06fae053b3be65ec tox -e <env to test>
     CORE_REPO_SHA={env:CORE_REPO_SHA:main}


### PR DESCRIPTION
# Description

@wangzlei and I worked together to figure out how to _mostly_ auto-instrument Lambda functions using the upstream `opentelemetry-instrument` [auto-instrumentation package](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/3049b4bfc5e2b64679f27543c1bd9d220047626e/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation).

In doing so, we found it best to re-write `otel-instrument` as a bash script.

We made two major updates

## Update the PYTHONPATH in `otel-instrument` so we can call `opentelemtry-instrument`

The auto-instrumentation package counts on 2 things:
* the `opentelemetry` package
* locating all the python packages the user wants to instrument

Both these 2 things require us modifying the environment variable `PYTHONPATH` right away in the `otel-instrument` script. AWS Lambda will add the correct paths but it does it too late. (It only does it once it calls it's originally intended entry point of `python3 /var/runtime/bootstrap.py`).

## Update the `otel_wrapper.py` to only call the `AwsLambdaInstrumentor`

All of the instrumentation is done in `sitecustomize.py` by `opentelemetry-instrument`. However, the way the Lambda Handler is imported in the AWS Lambda `bootstrap.py` file which is run after `sitecustomize.py` CLEARS any instrumentation done on `lambda_function.lambda_handler`. That's why we keep `otel_wrapper.py` around. So that `bootstrap.py` can call it, do any destructive imports it needs to do, and then call `AwsLambdaInstrumentor.instrument()` explicitly. This way we _know_ the Lambda function is instrumented, we can import, and give `bootstrap.py` the Lambda Handler that we know is instrumented.

## Future Work

We would ideally like to modify AWS Lambda's `boostrap.py` or investigate how we can get rid of `otel_wrapper.py` and have all the instrumentation be finished in `sitecustomize.py` such that `bootstrap.py` can just import the normal lambda handler at the `_HANDLER` environment variable without destroying the import at all.

Fixes #152 