### PR TITLE
feat: add logs coming from telemetry api

### DIFF
--- a/collector/internal/sharedcomponent/sharedcomponent.go
+++ b/collector/internal/sharedcomponent/sharedcomponent.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sharedcomponent exposes util functionality for receivers and exporters
+// that need to share state between different signal types instances such as net.Listener or os.File.
+package sharedcomponent // import "go.opentelemetry.io/collector/internal/sharedcomponent"
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+// SharedComponents a map that keeps reference of all created instances for a given configuration,
+// and ensures that the shared state is started and stopped only once.
+type SharedComponents struct {
+	comps map[interface{}]*SharedComponent
+}
+
+// NewSharedComponents returns a new empty SharedComponents.
+func NewSharedComponents() *SharedComponents {
+	return &SharedComponents{
+		comps: make(map[interface{}]*SharedComponent),
+	}
+}
+
+// GetOrAdd returns the already created instance if exists, otherwise creates a new instance
+// and adds it to the map of references.
+func (scs *SharedComponents) GetOrAdd(key interface{}, create func() (component.Component, error)) (*SharedComponent, error) {
+	if c, ok := scs.comps[key]; ok {
+		return c, nil
+	}
+	comp, err := create()
+	if err != nil {
+		return nil, err
+	}
+	newComp := &SharedComponent{
+		Component: comp,
+		removeFunc: func() {
+			delete(scs.comps, key)
+		},
+	}
+	scs.comps[key] = newComp
+	return newComp, nil
+}
+
+// SharedComponent ensures that the wrapped component is started and stopped only once.
+// When stopped it is removed from the SharedComponents map.
+type SharedComponent struct {
+	component.Component
+
+	startOnce  sync.Once
+	stopOnce   sync.Once
+	removeFunc func()
+}
+
+// Unwrap returns the original component.
+func (r *SharedComponent) Unwrap() component.Component {
+	return r.Component
+}
+
+// Start implements component.Component.
+func (r *SharedComponent) Start(ctx context.Context, host component.Host) error {
+	var err error
+	r.startOnce.Do(func() {
+		err = r.Component.Start(ctx, host)
+	})
+	return err
+}
+
+// Shutdown implements component.Component.
+func (r *SharedComponent) Shutdown(ctx context.Context) error {
+	var err error
+	r.stopOnce.Do(func() {
+		err = r.Component.Shutdown(ctx)
+		r.removeFunc()
+	})
+	return err
+}

--- a/collector/internal/sharedcomponent/sharedcomponent_test.go
+++ b/collector/internal/sharedcomponent/sharedcomponent_test.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sharedcomponent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+var id = component.NewID("test")
+
+type baseComponent struct {
+	component.StartFunc
+	component.ShutdownFunc
+}
+
+func TestNewSharedComponents(t *testing.T) {
+	comps := NewSharedComponents()
+	assert.Len(t, comps.comps, 0)
+}
+
+func TestNewSharedComponentsCreateError(t *testing.T) {
+	comps := NewSharedComponents()
+	assert.Len(t, comps.comps, 0)
+	myErr := errors.New("my error")
+	_, err := comps.GetOrAdd(id, func() (component.Component, error) { return nil, myErr })
+	assert.ErrorIs(t, err, myErr)
+	assert.Len(t, comps.comps, 0)
+}
+
+func TestSharedComponentsGetOrAdd(t *testing.T) {
+	nop := &baseComponent{}
+
+	comps := NewSharedComponents()
+	got, err := comps.GetOrAdd(id, func() (component.Component, error) { return nop, nil })
+	require.NoError(t, err)
+	assert.Len(t, comps.comps, 1)
+	assert.Same(t, nop, got.Unwrap())
+	gotSecond, err := comps.GetOrAdd(id, func() (component.Component, error) { panic("should not be called") })
+	require.NoError(t, err)
+	assert.Same(t, got, gotSecond)
+
+	// Shutdown nop will remove
+	assert.NoError(t, got.Shutdown(context.Background()))
+	assert.Len(t, comps.comps, 0)
+	gotThird, err := comps.GetOrAdd(id, func() (component.Component, error) { return nop, nil })
+	require.NoError(t, err)
+	assert.NotSame(t, got, gotThird)
+}
+
+func TestSharedComponent(t *testing.T) {
+	wantErr := errors.New("my error")
+	calledStart := 0
+	calledStop := 0
+	comp := &baseComponent{
+		StartFunc: func(ctx context.Context, host component.Host) error {
+			calledStart++
+			return wantErr
+		},
+		ShutdownFunc: func(ctx context.Context) error {
+			calledStop++
+			return wantErr
+		}}
+
+	comps := NewSharedComponents()
+	got, err := comps.GetOrAdd(id, func() (component.Component, error) { return comp, nil })
+	require.NoError(t, err)
+
+	assert.Equal(t, wantErr, got.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Equal(t, 1, calledStart)
+	// Second time is not called anymore.
+	assert.NoError(t, got.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Equal(t, 1, calledStart)
+	assert.Equal(t, wantErr, got.Shutdown(context.Background()))
+	assert.Equal(t, 1, calledStop)
+	// Second time is not called anymore.
+	assert.NoError(t, got.Shutdown(context.Background()))
+	assert.Equal(t, 1, calledStop)
+}

--- a/collector/internal/telemetryapi/client.go
+++ b/collector/internal/telemetryapi/client.go
@@ -49,7 +49,7 @@ func NewClient(logger *zap.Logger) *Client {
 func (c *Client) Subscribe(ctx context.Context, extensionID string, listenerURI string) (string, error) {
 	eventTypes := []EventType{
 		Platform,
-		// Function,
+		Function,
 		// Extension,
 	}
 

--- a/collector/receiver/telemetryapireceiver/factory.go
+++ b/collector/receiver/telemetryapireceiver/factory.go
@@ -42,11 +42,11 @@ func NewFactory(extensionID string) receiver.Factory {
 			}
 		},
 		receiver.WithTraces(createTracesReceiver, stability),
-		receiver.WithLogs(createLog, stability),
+		receiver.WithLogs(createLogsReceiver, stability),
 	)
 }
 
-func createLog(
+func createLogsReceiver(
 	_ context.Context,
 	params receiver.CreateSettings,
 	rConf component.Config,

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -101,9 +101,10 @@ func TestHandler(t *testing.T) {
 			consumer := mockConsumer{}
 			r, err := newTelemetryAPIReceiver(
 				&Config{},
-				&consumer,
 				receivertest.NewNopCreateSettings(),
 			)
+
+			r.nextTracesConsumer = &consumer
 			require.NoError(t, err)
 			req := httptest.NewRequest("POST",
 				"http://localhost:4323/someevent", strings.NewReader(tc.body))
@@ -148,9 +149,9 @@ func TestCreatePlatformInitSpan(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			r, err := newTelemetryAPIReceiver(
 				&Config{},
-				nil,
 				receivertest.NewNopCreateSettings(),
 			)
+
 			require.NoError(t, err)
 			td, err := r.createPlatformInitSpan(tc.start, tc.end)
 			if tc.expectError {

--- a/collector/receiver/telemetryapireceiver/types.go
+++ b/collector/receiver/telemetryapireceiver/types.go
@@ -15,7 +15,7 @@
 package telemetryapireceiver // import "github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver"
 
 type event struct {
-	Time   string         `json:"time"`
-	Type   string         `json:"type"`
-	Record map[string]any `json:"record"`
+	Time   string `json:"time"`
+	Type   string `json:"type"`
+	Record any    `json:"record"`
 }


### PR DESCRIPTION
Adding support for logs coming from AWS Telemetry API

Shared component library was copied from https://github.com/open-telemetry/opentelemetry-collector/tree/main/internal/sharedcomponent