### PR TITLE
fix: remove debug logs and use the diag logger for init timings

### DIFF
--- a/nodejs/packages/layer/src/init.mjs
+++ b/nodejs/packages/layer/src/init.mjs
@@ -2,8 +2,9 @@ const WRAPPER_INIT_START_TIME = Date.now();
 const { default: wrapper } = await import('./wrapper.js');
 await wrapper.init();
 await wrapper.wrap();
-console.log('OpenTelemetry wrapper init completed in', Date.now() - WRAPPER_INIT_START_TIME, 'ms');
+
+wrapper.logDebug('OpenTelemetry wrapper init completed in', Date.now() - WRAPPER_INIT_START_TIME, 'ms');
 
 const LOADER_INIT_START_TIME = Date.now();
 await import('./loader.mjs');
-console.log('OpenTelemetry loader init completed in', Date.now() - LOADER_INIT_START_TIME, 'ms');
+wrapper.logDebug('OpenTelemetry loader init completed in', Date.now() - LOADER_INIT_START_TIME, 'ms');

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -610,7 +610,9 @@ export async function init() {
   initialized = true;
 }
 
-console.log('Registering OpenTelemetry');
+export function logDebug(message: string, ...args: unknown[]) {
+  diag.debug(message, ...args);
+}
 
 let initialized = false;
 let instrumentations: Instrumentation[];


### PR DESCRIPTION
As discussed during the SIG meeting, let's remove the `Registering OpenTelemetry` log as this is showing in plain text (not JSON formatted) 
see picture below:
<img width="546" alt="Screenshot 2025-06-10 at 11 46 19 PM" src="https://github.com/user-attachments/assets/2a662c6b-7332-4a7d-924e-9e660b1de478" />

The init duration information can definitely be useful so I propose to use the diag logger and set the level to `DEBUG`. This way a customer using `INFO` log, won't see any plain text logs.