### PR TITLE
chore(nodejs): change from loggerProvider.addLogRecordProcessor() to 'processors' constructor arg

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -504,20 +504,18 @@ async function initializeLoggerProvider(
   );
 
   const logExporter = new OTLPLogExporter();
-  const logRecordProcessors: LogRecordProcessor[] = []
+  const logRecordProcessors: LogRecordProcessor[] = [];
   const loggerConfig = {
     resource,
-    processors: logRecordProcessors
+    processors: logRecordProcessors,
   };
   if (typeof configureLoggerProvider !== 'function') {
-    logRecordProcessors.push(
-      new BatchLogRecordProcessor(logExporter)
-    );
+    logRecordProcessors.push(new BatchLogRecordProcessor(logExporter));
   }
   // Logging for debug
   if (logLevel === DiagLogLevel.DEBUG) {
     logRecordProcessors.push(
-      new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())
+      new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()),
     );
   }
   const loggerProvider = new LoggerProvider(loggerConfig);


### PR DESCRIPTION
This will fix the CI failure in #1897. `@opentelemetry/sdk-logs@0.203.0`
*dropped* the deprecated `LoggerProvider#addLogRecordProcessor(...)`
method.

Refs: https://github.com/open-telemetry/opentelemetry-js/pull/5764

---

Note that the (undocumented?) `configureLoggerProvider` *global* might not be as useful anymore. A user specifying that global function will no longer be able to add a LogRecordProcessor to the given LoggerProvider instance. I'm not sure if `configureLoggerProvider` is considered a promised interface.

Unrelated to this PR, it might make sense to change `configureLoggerProvider` to be more like `configureTracer`. The latter is given a *config object* to customize that is later given to `new NodeTracerProvider(config);`. This would be a more future-proof API.