### PR TITLE
fix: retain configured span processors

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -412,7 +412,7 @@ async function initializeTracerProvider(
   }
 
   if (exporters.length) {
-    config.spanProcessors = [];
+    config.spanProcessors = config.spanProcessors || [];
     exporters.map(exporter => {
       if (exporter instanceof ConsoleSpanExporter) {
         config.spanProcessors?.push(new SimpleSpanProcessor(exporter));


### PR DESCRIPTION
Fixes #1923

Previously defining OTEL exporter would have removed any spanProcessors defined by configureTracer