### PR TITLE
feat(receiver): aws-like report log for invocations

### DIFF
--- a/collector/internal/telemetryapi/types.go
+++ b/collector/internal/telemetryapi/types.go
@@ -97,3 +97,15 @@ type Event struct {
 	Type   string         `json:"type"`
 	Record map[string]any `json:"record"`
 }
+
+// MetricType represents the type of metric in the platform.report event
+// see https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#ReportMetrics
+type MetricType string
+
+const (
+	MetricBilledDurationMs MetricType = "billedDurationMs"
+	MetricDurationMs       MetricType = "durationMs"
+	MetricMaxMemoryUsedMB  MetricType = "maxMemoryUsedMB"
+	MetricMemorySizeMB     MetricType = "memorySizeMB"
+	MetricInitDurationMs   MetricType = "initDurationMs"
+)

--- a/collector/internal/telemetryapi/types.go
+++ b/collector/internal/telemetryapi/types.go
@@ -24,6 +24,8 @@ const (
 	PlatformInitStart EventType = Platform + ".initStart"
 	// PlatformInitRuntimeDone is used when function initialization ended.
 	PlatformInitRuntimeDone EventType = Platform + ".initRuntimeDone"
+	// PlatformReport is used when a report of function invocation is received.
+	PlatformReport EventType = Platform + ".report"
 	// Function invocation started.
 	PlatformStart EventType = Platform + ".start"
 	// The runtime finished processing an event with either success or failure.

--- a/collector/receiver/telemetryapireceiver/config.go
+++ b/collector/receiver/telemetryapireceiver/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	extensionID string
 	Port        int      `mapstructure:"port"`
 	Types       []string `mapstructure:"types"`
+	LogReport   bool     `mapstructure:"log_report"`
 }
 
 // Validate validates the configuration by checking for missing or invalid fields

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -44,13 +44,7 @@ import (
 const (
 	initialQueueSize = 5
 	scopeName        = "github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapi"
-
-	logReportFmt           = "REPORT RequestId: %s Duration: %.2f ms Billed Duration: %.0f ms Memory Size: %.0f MB Max Memory Used: %.0f MB"
-	metricBilledDurationMs = "billedDurationMs"
-	metricDurationMs       = "durationMs"
-	metricMaxMemoryUsedMB  = "maxMemoryUsedMB"
-	metricMemorySizeMB     = "memorySizeMB"
-	metricInitDurationMs   = "initDurationMs"
+	logReportFmt     = "REPORT RequestId: %s Duration: %.2f ms Billed Duration: %.0f ms Memory Size: %.0f MB Max Memory Used: %.0f MB"
 )
 
 type telemetryAPIReceiver struct {
@@ -279,16 +273,16 @@ func createReportLogRecord(scopeLog *plog.ScopeLogs, record map[string]interface
 		return nil
 	}
 	var durationMs, billedDurationMs, memorySizeMB, maxMemoryUsedMB float64
-	if durationMs, ok = metrics[metricDurationMs].(float64); !ok {
+	if durationMs, ok = metrics[string(telemetryapi.MetricDurationMs)].(float64); !ok {
 		return nil
 	}
-	if billedDurationMs, ok = metrics[metricBilledDurationMs].(float64); !ok {
+	if billedDurationMs, ok = metrics[string(telemetryapi.MetricBilledDurationMs)].(float64); !ok {
 		return nil
 	}
-	if memorySizeMB, ok = metrics[metricMemorySizeMB].(float64); !ok {
+	if memorySizeMB, ok = metrics[string(telemetryapi.MetricMemorySizeMB)].(float64); !ok {
 		return nil
 	}
-	if maxMemoryUsedMB, ok = metrics[metricMaxMemoryUsedMB].(float64); !ok {
+	if maxMemoryUsedMB, ok = metrics[string(telemetryapi.MetricMaxMemoryUsedMB)].(float64); !ok {
 		return nil
 	}
 

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -288,7 +288,7 @@ func createReportLogRecord(scopeLog *plog.ScopeLogs, record map[string]interface
 
 	// optionally gather information about cold start time
 	var initDurationMs float64
-	if initDurationMsVal, exists := metrics[metricInitDurationMs]; exists {
+	if initDurationMsVal, exists := metrics[string(telemetryapi.MetricInitDurationMs)]; exists {
 		if val, ok := initDurationMsVal.(float64); ok {
 			initDurationMs = val
 		}

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -253,8 +253,6 @@ func (r *telemetryAPIReceiver) createLogs(slice []event) (plog.Logs, error) {
 						if t, err := time.Parse(time.RFC3339, el.Time); err == nil {
 							logRecord.SetTimestamp(pcommon.NewTimestampFromTime(t))
 							logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-						} else {
-							continue
 						}
 					}
 				}

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -527,6 +527,7 @@ func TestCreateLogsWithLogReport(t *testing.T) {
 		expectedType              string
 		expectedTimestamp         string
 		expectedBody              string
+		expectedAttributes        map[string]interface{}
 		expectError               bool
 	}{
 		{

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -539,9 +539,9 @@ func TestCreateLogsWithLogReport(t *testing.T) {
 						"requestId": "test-request-id-123",
 						"metrics": map[string]any{
 							"durationMs":       123.45,
-							"billedDurationMs": 124,
-							"memorySizeMB":     512,
-							"maxMemoryUsedMB":  256,
+							"billedDurationMs": float64(124),
+							"memorySizeMB":     float64(512),
+							"maxMemoryUsedMB":  float64(256),
 						},
 					},
 				},
@@ -662,6 +662,56 @@ func TestCreateLogsWithLogReport(t *testing.T) {
 			},
 			logReport:          true,
 			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.report with logReport enabled - with initDurationMs",
+			slice: []event{
+				{
+					Time: "2022-10-12T00:03:50.000Z",
+					Type: "platform.report",
+					Record: map[string]any{
+						"requestId": "test-request-id-123",
+						"metrics": map[string]any{
+							"durationMs":       123.45,
+							"billedDurationMs": 124.0,
+							"memorySizeMB":     512.0,
+							"maxMemoryUsedMB":  256.0,
+							"initDurationMs":   50.5,
+						},
+					},
+				},
+			},
+			logReport:          true,
+			expectedLogRecords: 1,
+			expectedType:       "platform.report",
+			expectedTimestamp:  "2022-10-12T00:03:50.000Z",
+			expectedBody:       "REPORT RequestId: test-request-id-123 Duration: 123.45 ms Billed Duration: 124 ms Memory Size: 512 MB Max Memory Used: 256 MB Init Duration: 50.50 ms",
+			expectError:        false,
+		},
+		{
+			desc: "platform.report with logReport enabled - with invalid initDurationMs type",
+			slice: []event{
+				{
+					Time: "2022-10-12T00:03:50.000Z",
+					Type: "platform.report",
+					Record: map[string]any{
+						"requestId": "test-request-id-123",
+						"metrics": map[string]any{
+							"durationMs":       123.45,
+							"billedDurationMs": 124.0,
+							"memorySizeMB":     512.0,
+							"maxMemoryUsedMB":  256.0,
+							"initDurationMs":   "invalid-string",
+						},
+					},
+				},
+			},
+			logReport:          true,
+			expectedLogRecords: 1,
+			expectedType:       "platform.report",
+			expectedTimestamp:  "2022-10-12T00:03:50.000Z",
+			expectedBody:       "REPORT RequestId: test-request-id-123 Duration: 123.45 ms Billed Duration: 124 ms Memory Size: 512 MB Max Memory Used: 256 MB",
 			expectError:        false,
 		},
 	}


### PR DESCRIPTION
## Description

AWS Lambda users can see the following report in AWS Cloudwatch after the invocation has finished:
```
REPORT RequestId: bf5f58db-ef7d-4cb2-b3c6-266eba1bbedb Duration: 395.99 ms Billed Duration: 662 ms Memory Size: 512 MB Max Memory Used: 301 MB Init Duration: 265.72 ms
```
This pull request adds the ability to display these report and send them along with the regular Lambda application logs. This feature is hidden behind a flag (`log_report`), which is turned off by default.

Contrary to what someone could expect [based on the documentation](https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#ReportMetrics), these metrics are all floats, attempt to parse them as integers would fail.

## Testing

Added unit test coverage, and tested in a production environment. 
Attaching a Grafana log query for evidence (we're using Otel -> Alloy -> Loki -> Grafana pipeline)

Collector config extract:
```yaml
receivers:
  telemetryapi:
    types: [platform, function]
    log_report: true

extensions:
  basicauth/otlp:
    ...

exporters:
  otlphttp:
    auth:
      authenticator: basicauth/otlp
    endpoint: ...

processors:
  batch: {}
  decouple: {}

service:
  pipelines:
    logs:
      receivers: [telemetryapi]
      processors: [batch, decouple]
      exporters: [otlphttp]
  extensions: [basicauth/otlp]
```

<img width="686" height="432" alt="Screenshot 2025-10-29 at 15 35 14" src="https://github.com/user-attachments/assets/0e2f2484-148c-47aa-a04b-12e295496bcf" />

