### PR TITLE
build: add typeRoots to tsconfig as fix for possible conflicts with other types in repositories with this repo as submodule

### DIFF
--- a/nodejs/tsconfig.base.json
+++ b/nodejs/tsconfig.base.json
@@ -19,7 +19,7 @@
     "incremental": true,
     "newLine": "LF",
     "typeRoots": [
-      "./node_modules/@types"
+      "node_modules/@types"
     ]
   },
   "exclude": [

--- a/nodejs/tsconfig.base.json
+++ b/nodejs/tsconfig.base.json
@@ -17,7 +17,10 @@
     "strictNullChecks": true,
     "target": "es2022",
     "incremental": true,
-    "newLine": "LF"
+    "newLine": "LF",
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   },
   "exclude": [
     "node_modules"

--- a/nodejs/tsconfig.esm.json
+++ b/nodejs/tsconfig.esm.json
@@ -20,7 +20,7 @@
     "incremental": true,
     "newLine": "LF",
     "typeRoots": [
-      "./node_modules/@types"
+      "node_modules/@types"
     ]
   },
   "exclude": [

--- a/nodejs/tsconfig.esm.json
+++ b/nodejs/tsconfig.esm.json
@@ -18,7 +18,10 @@
     "strict": true,
     "strictNullChecks": true,
     "incremental": true,
-    "newLine": "LF"
+    "newLine": "LF",
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
# Description

When building the OpenTelemetry Lambda collector and wrapper as a submodule of other repositories (for example as part of AWS CDK infrastructure repository) `mocha` types may conflict with `jest` types. Therefore some additional changes required to explicitly set the type roots for nodejs's lambda wrapper.