### PR TITLE
bump: instrumentation-aws-lambda to 0.61.0

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -3398,23 +3398,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.59.0.tgz",
-      "integrity": "sha512-Qf1kSg44SLm1EQfpe4PlSJ4lYGpc0ut6PLQgLzpLtYQRNF1IzioSy/+dkab6tsQ2z/teZIzqSaujrJgZpF/wWA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.207.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/aws-lambda": "8.10.155"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
       "version": "0.63.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.63.0.tgz",
@@ -19611,7 +19594,7 @@
         "@opentelemetry/exporter-trace-otlp-http": "^0.207.0",
         "@opentelemetry/instrumentation": "^0.207.0",
         "@opentelemetry/instrumentation-amqplib": "^0.54.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.59.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.61.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.63.0",
         "@opentelemetry/instrumentation-bunyan": "^0.53.0",
         "@opentelemetry/instrumentation-cassandra-driver": "^0.53.0",
@@ -19663,6 +19646,52 @@
       },
       "engines": {
         "node": ">=18.19.0"
+      }
+    },
+    "packages/layer/node_modules/@opentelemetry/instrumentation-aws-lambda": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.61.0.tgz",
+      "integrity": "sha512-yS7lzFhPL37CsGHolNSGA4UnEgiyyO/to1hHXcQ54JCOc4dVHxI319v5/A/UkVlcY7kF85RzqtKyBUZh7XxQWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.208.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/aws-lambda": "^8.10.155"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/layer/node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/layer/node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
+      "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "sample-apps/aws-sdk": {

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -44,7 +44,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.207.0",
     "@opentelemetry/instrumentation": "^0.207.0",
     "@opentelemetry/instrumentation-amqplib": "^0.54.0",
-    "@opentelemetry/instrumentation-aws-lambda": "^0.59.0",
+    "@opentelemetry/instrumentation-aws-lambda": "^0.61.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.63.0",
     "@opentelemetry/instrumentation-bunyan": "^0.53.0",
     "@opentelemetry/instrumentation-cassandra-driver": "^0.53.0",


### PR DESCRIPTION
This PR bumps instrumentation-aws-lambda to 0.61.0
Solving #2034