### PR TITLE
Externalize RITM

### DIFF
--- a/nodejs/packages/layer/install-externals.sh
+++ b/nodejs/packages/layer/install-externals.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 rm -rf ./build/workspace/node_modules
 
 # Space separated list of external NPM packages
-EXTERNAL_PACKAGES=( "import-in-the-middle" )
+EXTERNAL_PACKAGES=( "import-in-the-middle" "require-in-the-middle" )
 
 for EXTERNAL_PACKAGE in "${EXTERNAL_PACKAGES[@]}"
 do

--- a/nodejs/packages/layer/webpack.config.js
+++ b/nodejs/packages/layer/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
   externals: [
     'import-in-the-middle',
     '@aws-sdk',
+    'require-in-the-middle'
   ],
   output: {
     path: path.resolve('./build/src'),


### PR DESCRIPTION
Since RITM upgrade to v8.0.0 in @opentelemetry/instrumentation, a fallback on the `resolve` module was removed: https://github.com/nodejs/require-in-the-middle/commit/67076ff3b0dc16c3db71de335285e07ed1137dc1#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L73

This fallback seems not to have been intended to support bundled code, but as a side effect it did. When bundling code with webpack, webpack provides its own loader instead of the node.js native `require.resolve`. When using `require.resolve` inside code bundled with webpack, it can only resolve modules that are in the bundle. The above link to the old code highlights the check for `require.resolve && require.resolve.paths` both being truthy. This check would fail since the `require.resolve.paths` is undefined since it isn't needed in webpack's "stubbed" `require.resolve`, leading to the `resolve` module being used instead.

So since this change was introduced, that is actually breaking instrumentation that needs to hook non-core modules through RITM.

This change externalizes the RITM dependency so it can make use of the actual node.js `require.resolve` in the node.js runtime instead of the webpack loader.