### PR TITLE
fix: update supported runtimes

### DIFF
--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -128,7 +128,7 @@ jobs:
       artifact-name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip
       layer-name: opentelemetry-collector
       architecture: ${{ matrix.architecture }}
-      runtimes: "nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.9 python3.10 python3.11 python3.12 python3.13"
+      runtimes: "nodejs20.x nodejs22.x nodejs24.x java11 java17 java21 java25 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14"
       release-group: prod
       aws_region: ${{ matrix.aws_region }}
       role-arn: ${{ github.event.inputs.role-arn }}

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -95,7 +95,7 @@ jobs:
       # architecture:
       # If you add a nodejs runtime here, please make sure that the collector/Makefile publish and publish-layer targets
       # get updated as well
-      runtimes: nodejs18.x nodejs20.x nodejs22.x
+      runtimes: nodejs20.x nodejs22.x nodejs24.x
       release-group: prod
       aws_region: ${{ matrix.aws_region }}
     secrets: inherit

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -47,12 +47,12 @@ package: build
 
 .PHONY: publish
 publish:
-	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.9 python3.10 python3.11 python3.12 python3.13 --query 'LayerVersionArn' --output text
+	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs20.x nodejs22.x nodejs24.x java11 java17 java21 java25 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 --query 'LayerVersionArn' --output text
 
 .PHONY: publish-layer
 publish-layer: package
 	@echo Publishing collector extension layer...
-	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.9 python3.10 python3.11 python3.12 python3.13 --query 'LayerVersionArn' --output text
+	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs20.x nodejs22.x nodejs24.x java11 java17 java21 java25 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 --query 'LayerVersionArn' --output text
 	@echo OpenTelemetry Collector layer published.
 
 .PHONY: set-otelcol-version


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-lambda/issues/2039

This PR removes deprecated runtimes and adds newly released runtimes

replacing https://github.com/open-telemetry/opentelemetry-lambda/pull/2040 