### PR TITLE
fix(nodejs): register import in the middle for nodejs24.x runtime

### DIFF
--- a/nodejs/packages/layer/src/loader.mjs
+++ b/nodejs/packages/layer/src/loader.mjs
@@ -76,7 +76,16 @@ export function registerLoader() {
   }
 }
 
-if (_isHandlerAnESModule()) {
+function _getNodeRuntimeVersion() {
+  const executionEnv = process.env.AWS_EXECUTION_ENV || '';
+  const match = executionEnv.match(/nodejs(\d+)\.x/);
+  if (!match) {
+    return undefined;
+  }
+  return Number(match[1]);
+}
+
+if (_isHandlerAnESModule() || _getNodeRuntimeVersion() >= 24) {
   /*
   We could activate ESM loader hook of the "import-in-the-middle" library,
   - by "--loader=import-in-the-middle/hook.mjs" Node CLI option, but "--loader" option has been deprecated


### PR DESCRIPTION
solves #2034 

This change has been tested and fixes aws-lambda instrumentation again for commonjs lambda handlers using node 24 runtime.