### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         # If you add a python version here, please make sure that the collector/Makefile publish and publish-layer targets
         # get updated as well
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout this repo

--- a/python/sample-apps/template.yml
+++ b/python/sample-apps/template.yml
@@ -47,5 +47,6 @@ Resources:
         - python3.11
         - python3.12
         - python3.13
+        - python3.14
     Metadata:
       BuildMethod: makefile

--- a/python/src/otel/Dockerfile
+++ b/python/src/otel/Dockerfile
@@ -1,4 +1,4 @@
-ARG runtime=python3.13
+ARG runtime=python3.14
 
 FROM public.ecr.aws/sam/build-${runtime}
 

--- a/python/src/template.yml
+++ b/python/src/template.yml
@@ -19,5 +19,6 @@ Resources:
         - python3.11
         - python3.12
         - python3.13
+        - python3.14
     Metadata:
       BuildMethod: makefile

--- a/python/src/tox.ini
+++ b/python/src/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     ; opentelemetry-instrumentation-aws-lambda
-    py3{9,10,11,12}-test-instrumentation-aws-lambda
+    py3{9,10,11,12,13,14}-test-instrumentation-aws-lambda
 
 minversion = 3.9
 


### PR DESCRIPTION
Adds Python 3.14

Follow-up to https://github.com/open-telemetry/opentelemetry-lambda/pull/2041 with some additional places where python should be updated.