### PR TITLE
feat: Add support for exporting telemetry API 'platform.*' log events

### DIFF
--- a/collector/internal/telemetryapi/listener_test.go
+++ b/collector/internal/telemetryapi/listener_test.go
@@ -45,11 +45,6 @@ func setupListener(t *testing.T) (*Listener, string) {
 
 	address, err := listener.Start()
 	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		listener.Shutdown()
-	})
-
 	return listener, address
 }
 
@@ -183,6 +178,7 @@ func TestListenOnAddress(t *testing.T) {
 
 func TestListener_StartAndShutdown(t *testing.T) {
 	listener, address := setupListener(t)
+	defer listener.Shutdown()
 	require.NotEqual(t, address, "", "Start() should not return an empty address")
 	require.True(t, strings.HasPrefix(address, "http://"), "Address should start with http://")
 	require.NotNil(t, listener.httpServer, "httpServer should not be nil")
@@ -241,6 +237,7 @@ func TestListener_httpHandler(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			listener, address := setupListener(t)
+			defer listener.Shutdown()
 			submitEvents(t, address, test.events)
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				require.Equal(c, test.expectedCount, listener.queue.Len())
@@ -302,6 +299,7 @@ func TestListener_Wait_Success(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			listener, address := setupListener(t)
+			defer listener.Shutdown()
 
 			waitDone := make(chan error, 1)
 			go func() {

--- a/collector/internal/telemetryapi/listener_test.go
+++ b/collector/internal/telemetryapi/listener_test.go
@@ -178,7 +178,6 @@ func TestListenOnAddress(t *testing.T) {
 
 func TestListener_StartAndShutdown(t *testing.T) {
 	listener, address := setupListener(t)
-	defer listener.Shutdown()
 	require.NotEqual(t, address, "", "Start() should not return an empty address")
 	require.True(t, strings.HasPrefix(address, "http://"), "Address should start with http://")
 	require.NotNil(t, listener.httpServer, "httpServer should not be nil")
@@ -190,6 +189,7 @@ func TestListener_StartAndShutdown(t *testing.T) {
 		require.NoError(t, resp.Body.Close())
 	}
 
+	listener.Shutdown()
 	require.Nil(t, listener.httpServer, "httpServer should be nil after Shutdown()")
 }
 

--- a/collector/internal/telemetryapi/listener_test.go
+++ b/collector/internal/telemetryapi/listener_test.go
@@ -189,7 +189,6 @@ func TestListener_StartAndShutdown(t *testing.T) {
 	} else {
 		require.NoError(t, resp.Body.Close())
 	}
-	listener.Shutdown()
 
 	require.Nil(t, listener.httpServer, "httpServer should be nil after Shutdown()")
 }

--- a/collector/internal/telemetryapi/types.go
+++ b/collector/internal/telemetryapi/types.go
@@ -24,15 +24,29 @@ const (
 	PlatformInitStart EventType = Platform + ".initStart"
 	// PlatformInitRuntimeDone is used when function initialization ended.
 	PlatformInitRuntimeDone EventType = Platform + ".initRuntimeDone"
+	// PlatformInitReport is used when a report of function initialization is received.
+	PlatformInitReport EventType = Platform + ".initReport"
+	// PlatformStart is used when function invocation started.
+	PlatformStart EventType = Platform + ".start"
+	// PlatformRuntimeDone is used when the runtime finished processing an event with either success or failure.
+	PlatformRuntimeDone EventType = Platform + ".runtimeDone"
 	// PlatformReport is used when a report of function invocation is received.
 	PlatformReport EventType = Platform + ".report"
-	// Function invocation started.
-	PlatformStart EventType = Platform + ".start"
-	// The runtime finished processing an event with either success or failure.
-	PlatformRuntimeDone EventType = Platform + ".runtimeDone"
+	// PlatformRestoreStart is used when runtime restore started.
+	PlatformRestoreStart EventType = Platform + ".restoreStart"
+	// PlatformRestoreRuntimeDone is used when runtime restore completed.
+	PlatformRestoreRuntimeDone EventType = Platform + ".restoreRuntimeDone"
+	// PlatformRestoreReport is used when a report of runtime restore is received.
+	PlatformRestoreReport EventType = Platform + ".restoreReport"
+	// PlatformExtension is used for extension state events.
+	PlatformExtension EventType = Platform + ".extension"
+	// PlatformTelemetrySubscription is used when the extension subscribed to the Telemetry API.
+	PlatformTelemetrySubscription EventType = Platform + ".telemetrySubscription"
+	// PlatformLogsDropped is used when Lambda dropped log entries.
+	PlatformLogsDropped EventType = Platform + ".logsDropped"
 	// Function is used to receive log events emitted by the function
 	Function EventType = "function"
-	// Extension is used is to receive log events emitted by the extension
+	// Extension is used to receive log events emitted by the extension
 	Extension EventType = "extension"
 )
 

--- a/collector/lambdacomponents/receiver/telemetryapi.go
+++ b/collector/lambdacomponents/receiver/telemetryapi.go
@@ -17,8 +17,9 @@
 package receiver
 
 import (
-	"github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver"
 	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver"
 )
 
 func init() {

--- a/collector/receiver/telemetryapireceiver/config.go
+++ b/collector/receiver/telemetryapireceiver/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	extensionID string
 	Port        int      `mapstructure:"port"`
 	Types       []string `mapstructure:"types"`
-	LogReport   *bool    `mapstructure:"log_report"`
+	LogReport   bool     `mapstructure:"log_report"`
 }
 
 // Validate validates the configuration by checking for missing or invalid fields

--- a/collector/receiver/telemetryapireceiver/config.go
+++ b/collector/receiver/telemetryapireceiver/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	extensionID string
 	Port        int      `mapstructure:"port"`
 	Types       []string `mapstructure:"types"`
-	LogReport   bool     `mapstructure:"log_report"`
+	LogReport   *bool    `mapstructure:"log_report"`
 }
 
 // Validate validates the configuration by checking for missing or invalid fields

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -354,8 +354,8 @@ func createPlatformMessage(requestId string, functionVersion string, eventType s
 			return fmt.Sprintf(platformExtensionLogFmt, name, state, events)
 		}
 	case string(telemetryapi.PlatformLogsDropped):
-		droppedRecords, _ := record["droppedRecords"].(int64)
-		droppedBytes, _ := record["droppedBytes"].(int64)
+		droppedRecords, _ := record["droppedRecords"].(int32)
+		droppedBytes, _ := record["droppedBytes"].(int32)
 		reason, _ := record["reason"].(string)
 		if reason != "" {
 			return fmt.Sprintf(platformLogsDroppedLogFmt, int(droppedRecords), int(droppedBytes), reason)

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -354,8 +354,8 @@ func createPlatformMessage(requestId string, functionVersion string, eventType s
 			return fmt.Sprintf(platformExtensionLogFmt, name, state, events)
 		}
 	case string(telemetryapi.PlatformLogsDropped):
-		droppedRecords, _ := record["droppedRecords"].(int32)
-		droppedBytes, _ := record["droppedBytes"].(int32)
+		droppedRecords, _ := record["droppedRecords"].(float64)
+		droppedBytes, _ := record["droppedBytes"].(float64)
 		reason, _ := record["reason"].(string)
 		if reason != "" {
 			return fmt.Sprintf(platformLogsDroppedLogFmt, int(droppedRecords), int(droppedBytes), reason)

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -204,10 +204,10 @@ func (r *telemetryAPIReceiver) createLogs(slice []event) (plog.Logs, error) {
 	scopeLog := resourceLog.ScopeLogs().AppendEmpty()
 	scopeLog.Scope().SetName(scopeName)
 	for _, el := range slice {
-		r.logger.Debug(fmt.Sprintf("Event: %s", el.Type), zap.Any("event", el))
 		if !r.logReport && el.Type == string(telemetryapi.PlatformReport) {
 			continue
 		}
+		r.logger.Debug(fmt.Sprintf("Event: %s", el.Type), zap.Any("event", el))
 		logRecord := scopeLog.LogRecords().AppendEmpty()
 		logRecord.Attributes().PutStr("type", el.Type)
 		if t, err := time.Parse(time.RFC3339, el.Time); err == nil {

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -233,9 +233,9 @@ func (r *telemetryAPIReceiver) createLogs(slice []event) (plog.Logs, error) {
 			if requestId != "" {
 				logRecord.Attributes().PutStr(semconv.AttributeFaaSInvocationID, requestId)
 
-				// If this is the first event in the invocation with a request id (typically "platform.start"),
+				// If this is the first event in the invocation with a request id (i.e. the "platform.start" event),
 				// set the current invocation id to this request id.
-				if r.currentFaasInvocationID == "" {
+				if el.Type == string(telemetryapi.PlatformStart) {
 					r.currentFaasInvocationID = requestId
 				}
 			}

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -518,11 +518,6 @@ func newTelemetryAPIReceiver(
 		}
 	}
 
-	logReport := true
-	if cfg.LogReport != nil {
-		logReport = *cfg.LogReport
-	}
-
 	return &telemetryAPIReceiver{
 		logger:      set.Logger,
 		queue:       queue.New(initialQueueSize),
@@ -530,7 +525,7 @@ func newTelemetryAPIReceiver(
 		port:        cfg.Port,
 		types:       subscribedTypes,
 		resource:    r,
-		logReport:   logReport,
+		logReport:   cfg.LogReport,
 	}, nil
 }
 

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -852,7 +852,7 @@ func TestCreateLogsWithLogReport(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			r, err := newTelemetryAPIReceiver(
-				&Config{LogReport: &tc.logReport},
+				&Config{LogReport: tc.logReport},
 				receivertest.NewNopSettings(Type),
 			)
 			require.NoError(t, err)

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -1172,6 +1172,17 @@ func TestCreatePlatformMessage(t *testing.T) {
 					"durationMs": 0.0,
 				},
 			},
+			expected: "RESTORE_REPORT Status: success Duration: 0.00 ms",
+		},
+		{
+			desc:            "platform.restoreReport with no duration",
+			requestId:       "",
+			functionVersion: "",
+			eventType:       "platform.restoreReport",
+			record: map[string]interface{}{
+				"status":  "success",
+				"metrics": map[string]interface{}{},
+			},
 			expected: "",
 		},
 		{

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -1236,8 +1236,8 @@ func TestCreatePlatformMessage(t *testing.T) {
 			functionVersion: "",
 			eventType:       "platform.logsDropped",
 			record: map[string]interface{}{
-				"droppedRecords": int32(10),
-				"droppedBytes":   int32(1024),
+				"droppedRecords": float64(10),
+				"droppedBytes":   float64(1024),
 				"reason":         "",
 			},
 			expected: "",

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -1236,8 +1236,8 @@ func TestCreatePlatformMessage(t *testing.T) {
 			functionVersion: "",
 			eventType:       "platform.logsDropped",
 			record: map[string]interface{}{
-				"droppedRecords": int64(10),
-				"droppedBytes":   int64(1024),
+				"droppedRecords": int32(10),
+				"droppedBytes":   int32(1024),
 				"reason":         "",
 			},
 			expected: "",

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -604,7 +604,9 @@ func TestCreateLogs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			r, err := newTelemetryAPIReceiver(
-				&Config{},
+				&Config{
+					LogReport: true,
+				},
 				receivertest.NewNopSettings(Type),
 			)
 			require.NoError(t, err)

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -1224,8 +1224,8 @@ func TestCreatePlatformMessage(t *testing.T) {
 			functionVersion: "",
 			eventType:       "platform.logsDropped",
 			record: map[string]interface{}{
-				"droppedRecords": int64(10),
-				"droppedBytes":   int64(1024),
+				"droppedRecords": float64(10),
+				"droppedBytes":   float64(1024),
 				"reason":         "Consumer is too slow",
 			},
 			expected: "LOGS_DROPPED DroppedRecords: 10 DroppedBytes: 1024 Reason: Consumer is too slow",


### PR DESCRIPTION
Fixes issue #2054 where `platform.*` telemetry API event types (except part of `platform.report`) do not get exported for logging. The implemented solution captures all logs by default, and simplifies the current implementation by reusing the core log record construction logic while reducing code duplication.

I have setup a toy lambda function to export logs to Grafana Cloud with the changes in this PR, here are the updated logs:
<img width="1755" height="942" alt="Screenshot From 2025-12-08 18-31-52" src="https://github.com/user-attachments/assets/fe3165d0-faee-4c43-9e85-1b2159f2672d" />
