### PR TITLE
remove unnecessary call to AwsLambdaInstrumentor().instrument() in wrapper script

### DIFF
--- a/python/src/otel/otel_sdk/otel_wrapper.py
+++ b/python/src/otel/otel_sdk/otel_wrapper.py
@@ -48,9 +48,6 @@ def modify_module_name(module_name):
 class HandlerError(Exception):
     pass
 
-
-AwsLambdaInstrumentor().instrument()
-
 path = os.environ.get("ORIG_HANDLER")
 
 if path is None:

--- a/python/src/otel/otel_sdk/otel_wrapper.py
+++ b/python/src/otel/otel_sdk/otel_wrapper.py
@@ -37,7 +37,6 @@ https://docs.python.org/3/library/imp.html#imp.load_module
 import os
 from importlib import import_module
 
-from opentelemetry.instrumentation.aws_lambda import AwsLambdaInstrumentor
 
 
 def modify_module_name(module_name):

--- a/python/src/otel/tests/test_otel.py
+++ b/python/src/otel/tests/test_otel.py
@@ -153,6 +153,7 @@ def mock_execute_lambda(event=None):
     Args:
         event: The Lambda event which may or may not be used by instrumentation.
     """
+    AwsLambdaInstrumentor().instrument()
 
     # The point of the repo is to test using the script, so we can count on it
     # being here for every test and do not check for its existence.


### PR DESCRIPTION
Fixes: #2068 