### PR TITLE
feat(collector): optimize telemetryapireceiver trace and span id generation

### DIFF
--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -17,11 +17,9 @@ package telemetryapireceiver // import "github.com/open-telemetry/opentelemetry-
 import (
 	"context"
 	crand "crypto/rand"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"os"
 	"strconv"
@@ -102,20 +100,14 @@ func (r *telemetryAPIReceiver) Shutdown(ctx context.Context) error {
 }
 
 func newSpanID() pcommon.SpanID {
-	var rngSeed int64
-	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
-	randSource := rand.New(rand.NewSource(rngSeed))
 	sid := pcommon.SpanID{}
-	_, _ = randSource.Read(sid[:])
+	_, _ = crand.Read(sid[:])
 	return sid
 }
 
 func newTraceID() pcommon.TraceID {
-	var rngSeed int64
-	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
-	randSource := rand.New(rand.NewSource(rngSeed))
 	tid := pcommon.TraceID{}
-	_, _ = randSource.Read(tid[:])
+	_, _ = crand.Read(tid[:])
 	return tid
 }
 


### PR DESCRIPTION
Use `crypto/rand`'s `Read` method directly. Instead of reinitializing and seeding the rng on each span / trace id generation. Saving:

1. Heap allocations
    - `rand.NewSource(rngSeed)`
    - `rand.New(...)`
2. Some init logic - CPU time
    - `rand.NewSource(rngSeed)` - PRNG state initialization (also apparently [not safe for concurrent use](https://pkg.go.dev/math/rand#NewSource))
3. Probably negligible but function call overhead of calling `rand.NewSource(rngSeed)` and `rand.New(...)`

What remains now is basically a very efficient syscall, with no heap allocations.