### PR TITLE
build(collector): update Go to 1.24.11

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector
 
-go 1.24.4
+go 1.24.11
 
 replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents => ./lambdacomponents
 

--- a/collector/internal/tools/go.mod
+++ b/collector/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/internal/tools
 
-go 1.24.4
+go 1.24.11
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/collector/lambdacomponents/go.mod
+++ b/collector/lambdacomponents/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents
 
-go 1.24.4
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.143.0

--- a/collector/lambdalifecycle/go.mod
+++ b/collector/lambdalifecycle/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle
 
-go 1.24.4
+go 1.24.11

--- a/collector/processor/coldstartprocessor/go.mod
+++ b/collector/processor/coldstartprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor
 
-go 1.24.4
+go 1.24.11
 
 require (
 	github.com/cespare/xxhash v1.1.0

--- a/collector/processor/decoupleprocessor/go.mod
+++ b/collector/processor/decoupleprocessor/go.mod
@@ -2,7 +2,7 @@ module github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoup
 
 replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle => ../../lambdalifecycle
 
-go 1.24.4
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle v0.0.0-00010101000000-000000000000

--- a/collector/receiver/telemetryapireceiver/go.mod
+++ b/collector/receiver/telemetryapireceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver
 
-go 1.24.4
+go 1.24.11
 
 replace github.com/open-telemetry/opentelemetry-lambda/collector => ../../
 


### PR DESCRIPTION
Description:

- Update Go version from 1.24.4 to 1.24.11 across all collector modules

Note: The collector upgrade to v0.143.0 was already merged in #2105. This PR now only contains the Go version update.