### PR TITLE
feat: add configurable metric export interval to lambda telemetry API receiver

### DIFF
--- a/collector/receiver/telemetryapireceiver/README.md
+++ b/collector/receiver/telemetryapireceiver/README.md
@@ -1,10 +1,10 @@
 # Telemetry API Receiver
 
-| Status                   |              |
-| ------------------------ |--------------|
-| Stability                | [alpha]      |
-| Supported pipeline types | traces, logs |
-| Distributions            | [extension]  |
+| Status                   |                       |
+|--------------------------|-----------------------|
+| Stability                | [alpha]               |
+| Supported pipeline types | traces, logs, metrics |
+| Distributions            | [extension]           |
 
 This receiver generates telemetry in response to events from the [Telemetry API](https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api.html). It does this by setting up an endpoint and registering itself with the Telemetry API on startup.
 
@@ -15,10 +15,12 @@ Supported events:
 
 ## Configuration
 
-| Field   | Default                               | Description                                                                                                                             |
-|---------|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `port`  | 0 (dynamically determined by OS)      | HTTP server port to receive Telemetry API data.                                                                                         |
-| `types` | ["platform", "function", "extension"] | [Types](https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api-reference.html#telemetry-subscribe-api) of telemetry to subscribe to |
+| Field                 | Default                               | Description                                                                                                                                                          |
+|-----------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `port`                | 0 (dynamically determined by OS)      | HTTP server port to receive Telemetry API data.                                                                                                                      |
+| `types`               | ["platform", "function", "extension"] | [Types](https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api-reference.html#telemetry-subscribe-api) of telemetry to subscribe to                              |
+| `metrics_temporality` | cumulative                            | The [aggregation temporality](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) to use for metrics. Supported values: `delta`, `cumulative`. |
+| `export_interval_ms`  | 60000                                 | The interval in milliseconds at which metrics are exported. If set to 0, metrics are exported immediately upon receipt.                                              |
 
 
 ```yaml
@@ -26,11 +28,13 @@ receivers:
     telemetryapi:
     telemetryapi/1:
       port: 4326
+      export_interval_ms: 30000
     telemetryapi/2:
       port: 4327
       types:
         - platform
         - function
+      metrics_temporality: delta
     telemetryapi/3:
       port: 4328
       types: ["platform", "function"]

--- a/collector/receiver/telemetryapireceiver/config.go
+++ b/collector/receiver/telemetryapireceiver/config.go
@@ -26,10 +26,14 @@ type Config struct {
 	Types              []string `mapstructure:"types"`
 	LogReport          bool     `mapstructure:"log_report"`
 	MetricsTemporality string   `mapstructure:"metrics_temporality"`
+	ExportInterval     int      `mapstructure:"export_interval_ms"`
 }
 
 // Validate validates the configuration by checking for missing or invalid fields
 func (cfg *Config) Validate() error {
+	if cfg.ExportInterval < 0 {
+		return fmt.Errorf("export_interval_ms must be non-negative: %d", cfg.ExportInterval)
+	}
 	for _, t := range cfg.Types {
 		if t != platform && t != function && t != extension {
 			return fmt.Errorf("unknown extension type: %s", t)

--- a/collector/receiver/telemetryapireceiver/config_test.go
+++ b/collector/receiver/telemetryapireceiver/config_test.go
@@ -31,9 +31,10 @@ func TestLoadConfig(t *testing.T) {
 	// Helper function to create expected Config
 	createExpectedConfig := func(types []string) *Config {
 		return &Config{
-			extensionID: "extensionID",
-			Port:        12345,
-			Types:       types,
+			extensionID:    "extensionID",
+			Port:           12345,
+			Types:          types,
+			ExportInterval: defaultExportInterval,
 		}
 	}
 

--- a/collector/receiver/telemetryapireceiver/factory.go
+++ b/collector/receiver/telemetryapireceiver/factory.go
@@ -25,12 +25,13 @@ import (
 )
 
 const (
-	typeStr     = "telemetryapi"
-	stability   = component.StabilityLevelDevelopment
-	defaultPort = 0
-	platform    = "platform"
-	function    = "function"
-	extension   = "extension"
+	typeStr               = "telemetryapi"
+	stability             = component.StabilityLevelDevelopment
+	defaultPort           = 0
+	defaultExportInterval = 60000
+	platform              = "platform"
+	function              = "function"
+	extension             = "extension"
 )
 
 var (
@@ -44,9 +45,10 @@ func NewFactory(extensionID string) receiver.Factory {
 		Type,
 		func() component.Config {
 			return &Config{
-				extensionID: extensionID,
-				Port:        defaultPort,
-				Types:       []string{platform, function, extension},
+				extensionID:    extensionID,
+				Port:           defaultPort,
+				Types:          []string{platform, function, extension},
+				ExportInterval: defaultExportInterval,
 			}
 		},
 		receiver.WithTraces(createTracesReceiver, stability),

--- a/collector/receiver/telemetryapireceiver/factory_test.go
+++ b/collector/receiver/telemetryapireceiver/factory_test.go
@@ -41,7 +41,12 @@ func TestNewFactory(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				factory := NewFactory("test")
 
-				var expectedCfg component.Config = &Config{extensionID: "test", Port: defaultPort, Types: []string{platform, function, extension}}
+				var expectedCfg component.Config = &Config{
+					extensionID:    "test",
+					Port:           defaultPort,
+					Types:          []string{platform, function, extension},
+					ExportInterval: defaultExportInterval,
+				}
 
 				require.Equal(t, expectedCfg, factory.CreateDefaultConfig())
 			},

--- a/collector/receiver/telemetryapireceiver/metric_builder.go
+++ b/collector/receiver/telemetryapireceiver/metric_builder.go
@@ -127,7 +127,7 @@ func (h *HistogramMetricBuilder) AppendDataPoints(scopeMetrics pmetric.ScopeMetr
 		}
 	}
 
-	if !export {
+	if !export || len(h.dataPoints) == 0 {
 		return
 	}
 
@@ -249,7 +249,7 @@ func (c *CounterMetricBuilder) AppendDataPoints(scopeMetrics pmetric.ScopeMetric
 		}
 	}
 
-	if !export {
+	if !export || len(c.dataPoints) == 0 {
 		return
 	}
 

--- a/collector/receiver/telemetryapireceiver/metric_builder_test.go
+++ b/collector/receiver/telemetryapireceiver/metric_builder_test.go
@@ -648,6 +648,78 @@ func TestCounterMetricBuilder_CumulativeDataPoints(t *testing.T) {
 	})
 }
 
+func TestHistogramMetricBuilder_AppendDataPoints_NoData(t *testing.T) {
+	startTime := pcommon.NewTimestampFromTime(time.Now().Add(-time.Hour))
+
+	t.Run("cumulative temporality", func(t *testing.T) {
+		builder := NewHistogramMetricBuilder(
+			"test.histogram", "Test histogram", "ms",
+			nil, startTime, pmetric.AggregationTemporalityCumulative,
+		)
+
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		scopeMetrics := rm.ScopeMetrics().AppendEmpty()
+
+		timestamp := pcommon.NewTimestampFromTime(time.Now())
+		builder.AppendDataPoints(scopeMetrics, timestamp)
+
+		assert.Equal(t, 0, scopeMetrics.Metrics().Len())
+	})
+
+	t.Run("delta temporality", func(t *testing.T) {
+		builder := NewHistogramMetricBuilder(
+			"test.histogram", "Test histogram", "ms",
+			nil, startTime, pmetric.AggregationTemporalityDelta,
+		)
+
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		scopeMetrics := rm.ScopeMetrics().AppendEmpty()
+
+		timestamp := pcommon.NewTimestampFromTime(time.Now())
+		builder.AppendDataPoints(scopeMetrics, timestamp)
+
+		assert.Equal(t, 0, scopeMetrics.Metrics().Len())
+	})
+}
+
+func TestCounterMetricBuilder_AppendDataPoints_NoData(t *testing.T) {
+	startTime := pcommon.NewTimestampFromTime(time.Now().Add(-time.Hour))
+
+	t.Run("cumulative temporality", func(t *testing.T) {
+		builder := NewCounterMetricBuilder(
+			"test.counter", "Test counter", "{count}",
+			true, startTime, pmetric.AggregationTemporalityCumulative,
+		)
+
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		scopeMetrics := rm.ScopeMetrics().AppendEmpty()
+
+		timestamp := pcommon.NewTimestampFromTime(time.Now())
+		builder.AppendDataPoints(scopeMetrics, timestamp)
+
+		assert.Equal(t, 0, scopeMetrics.Metrics().Len())
+	})
+
+	t.Run("delta temporality", func(t *testing.T) {
+		builder := NewCounterMetricBuilder(
+			"test.counter", "Test counter", "{count}",
+			true, startTime, pmetric.AggregationTemporalityDelta,
+		)
+
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		scopeMetrics := rm.ScopeMetrics().AppendEmpty()
+
+		timestamp := pcommon.NewTimestampFromTime(time.Now())
+		builder.AppendDataPoints(scopeMetrics, timestamp)
+
+		assert.Equal(t, 0, scopeMetrics.Metrics().Len())
+	})
+}
+
 func TestHistogramMetricBuilder_AggregationTemporality(t *testing.T) {
 	startTime := pcommon.NewTimestampFromTime(time.Now().Add(-time.Hour))
 

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -84,6 +84,9 @@ type telemetryAPIReceiver struct {
 	currentFaasInvocationID string
 	lambdaInitType          lambdalifecycle.InitType
 	logReport               bool
+	exportInterval          time.Duration
+	stopCh                  chan struct{}
+	wg                      sync.WaitGroup
 }
 
 func (r *telemetryAPIReceiver) bindListener() (net.Listener, string, error) {
@@ -119,6 +122,11 @@ func (r *telemetryAPIReceiver) Start(ctx context.Context, host component.Host) e
 		}
 	}()
 
+	if r.exportInterval > 0 {
+		r.wg.Add(1)
+		go r.startMetricsExporter()
+	}
+
 	telemetryClient := telemetryapi.NewClient(r.logger)
 	if _, err := telemetryClient.Subscribe(ctx, r.types, r.extensionID, fmt.Sprintf("http://%s/", address)); err != nil {
 		r.logger.Error("Failed to subscribe to telemetry", zap.Error(err))
@@ -130,10 +138,70 @@ func (r *telemetryAPIReceiver) Start(ctx context.Context, host component.Host) e
 }
 
 func (r *telemetryAPIReceiver) Shutdown(ctx context.Context) error {
+	close(r.stopCh)
+	r.wg.Wait()
+
+	var errs []error
+
+	if r.exportInterval > 0 {
+		if err := r.flushMetrics(ctx); err != nil {
+			r.logger.Error("error while flushing metrics", zap.Error(err))
+			errs = append(errs, err)
+		}
+	}
+
 	if r.httpServer != nil {
 		if err := r.httpServer.Shutdown(ctx); err != nil {
-			return err
+			r.logger.Error("error shutting down http server", zap.Error(err))
+			errs = append(errs, err)
 		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (r *telemetryAPIReceiver) startMetricsExporter() {
+	defer r.wg.Done()
+	ticker := time.NewTicker(r.exportInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := r.flushMetrics(context.Background()); err != nil {
+				r.logger.Error("error while flushing metrics", zap.Error(err))
+			}
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+func (r *telemetryAPIReceiver) flushMetrics(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.flushMetricsLocked(ctx)
+}
+
+func (r *telemetryAPIReceiver) flushMetricsLocked(ctx context.Context) error {
+	metric := pmetric.NewMetrics()
+	resourceMetric := metric.ResourceMetrics().AppendEmpty()
+	r.resource.CopyTo(resourceMetric.Resource())
+	scopeMetric := resourceMetric.ScopeMetrics().AppendEmpty()
+	scopeMetric.Scope().SetName(scopeName)
+	scopeMetric.SetSchemaUrl(semconv.SchemaURL)
+
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	r.faaSMetricBuilders.coldstartsMetric.AppendDataPoints(scopeMetric, ts)
+	r.faaSMetricBuilders.errorsMetric.AppendDataPoints(scopeMetric, ts)
+	r.faaSMetricBuilders.timeoutsMetric.AppendDataPoints(scopeMetric, ts)
+	r.faaSMetricBuilders.initDurationMetric.AppendDataPoints(scopeMetric, ts)
+	r.faaSMetricBuilders.memUsageMetric.AppendDataPoints(scopeMetric, ts)
+	r.faaSMetricBuilders.invocationsMetric.AppendDataPoints(scopeMetric, ts)
+	r.faaSMetricBuilders.invokeDurationMetric.AppendDataPoints(scopeMetric, ts)
+
+	if metric.MetricCount() > 0 && r.nextMetrics != nil {
+		return r.nextMetrics.ConsumeMetrics(ctx, metric)
 	}
 	return nil
 }
@@ -236,12 +304,10 @@ func (r *telemetryAPIReceiver) httpHandler(w http.ResponseWriter, req *http.Requ
 	}
 	// Metrics
 	if r.nextMetrics != nil {
-		if metrics, err := r.createMetrics(slice); err == nil {
-			if metrics.MetricCount() > 0 {
-				err := r.nextMetrics.ConsumeMetrics(context.Background(), metrics)
-				if err != nil {
-					r.logger.Error("error receiving metrics", zap.Error(err))
-				}
+		r.recordMetrics(slice)
+		if r.exportInterval == 0 {
+			if err := r.flushMetricsLocked(context.Background()); err != nil {
+				r.logger.Error("error flushing metrics", zap.Error(err))
 			}
 		}
 	}
@@ -284,37 +350,22 @@ func (r *telemetryAPIReceiver) updateCurrentRequestId(requestId string) {
 	}
 }
 
-func (r *telemetryAPIReceiver) createMetrics(slice []event) (pmetric.Metrics, error) {
-	metric := pmetric.NewMetrics()
-	resourceMetric := metric.ResourceMetrics().AppendEmpty()
-	r.resource.CopyTo(resourceMetric.Resource())
-	scopeMetric := resourceMetric.ScopeMetrics().AppendEmpty()
-	scopeMetric.Scope().SetName(scopeName)
-	scopeMetric.SetSchemaUrl(semconv.SchemaURL)
-
+func (r *telemetryAPIReceiver) recordMetrics(slice []event) {
 	for _, el := range slice {
-		r.logger.Debug(fmt.Sprintf("Event: %s", el.Type), zap.Any("event", el))
 		record, ok := el.Record.(map[string]any)
 		if !ok {
-			continue
-		}
-		ts, err := time.Parse(time.RFC3339, el.Time)
-		if err != nil {
 			continue
 		}
 
 		switch el.Type {
 		case string(telemetryapi.PlatformInitStart):
 			r.faaSMetricBuilders.coldstartsMetric.Add(1)
-			r.faaSMetricBuilders.coldstartsMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 		case string(telemetryapi.PlatformInitReport):
 			status, _ := record["status"].(string)
 			if status == telemetryFailureStatus || status == telemetryErrorStatus {
 				r.faaSMetricBuilders.errorsMetric.Add(1)
-				r.faaSMetricBuilders.errorsMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 			} else if status == telemetryTimeoutStatus {
 				r.faaSMetricBuilders.timeoutsMetric.Add(1)
-				r.faaSMetricBuilders.timeoutsMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 			}
 
 			metrics, ok := record["metrics"].(map[string]any)
@@ -328,7 +379,6 @@ func (r *telemetryAPIReceiver) createMetrics(slice []event) (pmetric.Metrics, er
 			}
 
 			r.faaSMetricBuilders.initDurationMetric.Record(durationMs / 1000.0)
-			r.faaSMetricBuilders.initDurationMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 		case string(telemetryapi.PlatformReport):
 			metrics, ok := record["metrics"].(map[string]any)
 			if !ok {
@@ -338,20 +388,16 @@ func (r *telemetryAPIReceiver) createMetrics(slice []event) (pmetric.Metrics, er
 			maxMemoryUsedMb, ok := metrics["maxMemoryUsedMB"].(float64)
 			if ok {
 				r.faaSMetricBuilders.memUsageMetric.Record(maxMemoryUsedMb * 1000000.0)
-				r.faaSMetricBuilders.memUsageMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 			}
 		case string(telemetryapi.PlatformRuntimeDone):
 			status, _ := record["status"].(string)
 
 			if status == telemetrySuccessStatus {
 				r.faaSMetricBuilders.invocationsMetric.Add(1)
-				r.faaSMetricBuilders.invocationsMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 			} else if status == telemetryFailureStatus || status == telemetryErrorStatus {
 				r.faaSMetricBuilders.errorsMetric.Add(1)
-				r.faaSMetricBuilders.errorsMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 			} else if status == telemetryTimeoutStatus {
 				r.faaSMetricBuilders.timeoutsMetric.Add(1)
-				r.faaSMetricBuilders.timeoutsMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 			}
 
 			metrics, ok := record["metrics"].(map[string]any)
@@ -362,11 +408,9 @@ func (r *telemetryAPIReceiver) createMetrics(slice []event) (pmetric.Metrics, er
 			durationMs, ok := metrics["durationMs"].(float64)
 			if ok {
 				r.faaSMetricBuilders.invokeDurationMetric.Record(durationMs / 1000.0)
-				r.faaSMetricBuilders.invokeDurationMetric.AppendDataPoints(scopeMetric, pcommon.NewTimestampFromTime(ts))
 			}
 		}
 	}
-	return metric, nil
 }
 
 func (r *telemetryAPIReceiver) createLogs(slice []event) (plog.Logs, error) {
@@ -752,6 +796,8 @@ func newTelemetryAPIReceiver(
 		faaSMetricBuilders: NewFaaSMetricBuilders(pcommon.NewTimestampFromTime(time.Now()), getMetricsTemporality(cfg)),
 		lambdaInitType:     lambdaInitType,
 		logReport:          cfg.LogReport,
+		exportInterval:     time.Duration(cfg.ExportInterval) * time.Millisecond,
+		stopCh:             make(chan struct{}),
 	}, nil
 }
 

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -143,16 +143,16 @@ func (r *telemetryAPIReceiver) Shutdown(ctx context.Context) error {
 
 	var errs []error
 
-	if r.exportInterval > 0 {
-		if err := r.flushMetrics(ctx); err != nil {
-			r.logger.Error("error while flushing metrics", zap.Error(err))
+	if r.httpServer != nil {
+		if err := r.httpServer.Shutdown(ctx); err != nil {
+			r.logger.Error("error shutting down http server", zap.Error(err))
 			errs = append(errs, err)
 		}
 	}
 
-	if r.httpServer != nil {
-		if err := r.httpServer.Shutdown(ctx); err != nil {
-			r.logger.Error("error shutting down http server", zap.Error(err))
+	if r.exportInterval > 0 {
+		if err := r.flushMetrics(ctx); err != nil {
+			r.logger.Error("error while flushing metrics", zap.Error(err))
 			errs = append(errs, err)
 		}
 	}

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
@@ -82,7 +83,8 @@ func TestBindListener(t *testing.T) {
 }
 
 type mockConsumer struct {
-	consumed int
+	consumed      int
+	metricBatches []pmetric.Metrics
 }
 
 func (c *mockConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
@@ -94,8 +96,121 @@ func (c *mockConsumer) ConsumeLogs(ctx context.Context, td plog.Logs) error {
 	return nil
 }
 
+func (c *mockConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	c.metricBatches = append(c.metricBatches, md)
+	return nil
+}
+
 func (c *mockConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
+}
+
+func TestRecordMetrics(t *testing.T) {
+	r, err := newTelemetryAPIReceiver(
+		&Config{},
+		receivertest.NewNopSettings(Type),
+	)
+	require.NoError(t, err)
+
+	slice := []event{
+		{
+			Type: "platform.initStart",
+			Record: map[string]any{
+				"functionName": "test-func",
+			},
+		},
+		{
+			Type: "platform.runtimeDone",
+			Record: map[string]any{
+				"status": "success",
+				"metrics": map[string]any{
+					"durationMs": 100.0,
+				},
+			},
+		},
+	}
+
+	r.recordMetrics(slice)
+
+	c := &mockConsumer{}
+	r.registerMetricsConsumer(c)
+	r.flushMetrics(context.Background())
+
+	require.Len(t, c.metricBatches, 1)
+	metrics := c.metricBatches[0]
+	require.Equal(t, 3, metrics.MetricCount()) // coldstarts, invocations and duration
+
+	foundColdstart := false
+	foundInvocation := false
+	foundDuration := false
+	rm := metrics.ResourceMetrics().At(0)
+	sm := rm.ScopeMetrics().At(0)
+	for i := 0; i < sm.Metrics().Len(); i++ {
+		m := sm.Metrics().At(i)
+		if m.Name() == semconv.FaaSColdstartsName {
+			foundColdstart = true
+		}
+		if m.Name() == semconv.FaaSInvocationsName {
+			foundInvocation = true
+		}
+		if m.Name() == semconv.FaaSInvokeDurationName {
+			foundDuration = true
+		}
+	}
+	require.True(t, foundColdstart)
+	require.True(t, foundInvocation)
+	require.True(t, foundDuration)
+}
+
+func TestFlushMetricsIntervalImmediate(t *testing.T) {
+	// Test immediate flush when interval = 0
+	r, err := newTelemetryAPIReceiver(
+		&Config{ExportInterval: 0},
+		receivertest.NewNopSettings(Type),
+	)
+	require.NoError(t, err)
+	c := &mockConsumer{}
+	r.registerMetricsConsumer(c)
+
+	req := httptest.NewRequest("POST", "http://localhost/", strings.NewReader(`[{"time":"2006-01-02T15:04:04.000Z", "type":"platform.initStart", "record": {"foo":"bar"}}]`))
+	r.httpHandler(httptest.NewRecorder(), req)
+	require.Len(t, c.metricBatches, 1)
+}
+
+func TestFlushMetricsIntervalDelayed(t *testing.T) {
+	// Test delayed flush when interval > 0
+	r, err := newTelemetryAPIReceiver(
+		&Config{ExportInterval: 60000},
+		receivertest.NewNopSettings(Type),
+	)
+	require.NoError(t, err)
+	c := &mockConsumer{}
+	r.registerMetricsConsumer(c)
+
+	req := httptest.NewRequest("POST", "http://localhost/", strings.NewReader(`[{"time":"2006-01-02T15:04:04.000Z", "type":"platform.initStart", "record": {"foo":"bar"}}]`))
+	r.httpHandler(httptest.NewRecorder(), req)
+	require.Len(t, c.metricBatches, 0)
+
+	r.flushMetrics(context.Background())
+	require.Len(t, c.metricBatches, 1)
+}
+
+func TestShutdownFlushesMetrics(t *testing.T) {
+	r, err := newTelemetryAPIReceiver(
+		&Config{ExportInterval: 60000},
+		receivertest.NewNopSettings(Type),
+	)
+	require.NoError(t, err)
+	c := &mockConsumer{}
+	r.registerMetricsConsumer(c)
+
+	req := httptest.NewRequest("POST", "http://localhost/", strings.NewReader(`[{"time":"2006-01-02T15:04:04.000Z", "type":"platform.initStart", "record": {"foo":"bar"}}]`))
+	r.httpHandler(httptest.NewRecorder(), req)
+	require.Len(t, c.metricBatches, 0)
+
+	err = r.Shutdown(context.Background())
+	require.NoError(t, err)
+	require.Len(t, c.metricBatches, 1)
 }
 
 func TestHandler(t *testing.T) {

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -847,7 +847,7 @@ func TestCreateLogsWithLogReport(t *testing.T) {
 					Type: "platform.report",
 					Record: map[string]any{
 						"requestId": "test-request-id-123",
-						"status": "success",
+						"status":    "success",
 						"metrics": map[string]any{
 							"durationMs":       123.45,
 							"billedDurationMs": float64(124),

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -134,7 +134,8 @@ func TestRecordMetrics(t *testing.T) {
 
 	c := &mockConsumer{}
 	r.registerMetricsConsumer(c)
-	r.flushMetrics(context.Background())
+	err = r.flushMetrics(context.Background())
+	require.NoError(t, err)
 
 	require.Len(t, c.metricBatches, 1)
 	metrics := c.metricBatches[0]
@@ -191,7 +192,8 @@ func TestFlushMetricsIntervalDelayed(t *testing.T) {
 	r.httpHandler(httptest.NewRecorder(), req)
 	require.Len(t, c.metricBatches, 0)
 
-	r.flushMetrics(context.Background())
+	err = r.flushMetrics(context.Background())
+	require.NoError(t, err)
 	require.Len(t, c.metricBatches, 1)
 }
 
@@ -211,6 +213,41 @@ func TestShutdownFlushesMetrics(t *testing.T) {
 	err = r.Shutdown(context.Background())
 	require.NoError(t, err)
 	require.Len(t, c.metricBatches, 1)
+}
+
+func TestFlushMetricsNilConsumer(t *testing.T) {
+	r, err := newTelemetryAPIReceiver(
+		&Config{},
+		receivertest.NewNopSettings(Type),
+	)
+	require.NoError(t, err)
+
+	slice := []event{
+		{
+			Type: "platform.initStart",
+			Record: map[string]any{
+				"functionName": "test-func",
+			},
+		},
+	}
+	r.recordMetrics(slice)
+
+	err = r.flushMetrics(context.Background())
+	require.NoError(t, err)
+}
+
+func TestFlushMetricsNoData(t *testing.T) {
+	r, err := newTelemetryAPIReceiver(
+		&Config{},
+		receivertest.NewNopSettings(Type),
+	)
+	require.NoError(t, err)
+	c := &mockConsumer{}
+	r.registerMetricsConsumer(c)
+
+	err = r.flushMetrics(context.Background())
+	require.NoError(t, err)
+	require.Len(t, c.metricBatches, 0)
 }
 
 func TestHandler(t *testing.T) {


### PR DESCRIPTION
Followup to changes made in #2066. The changes in this PR add a configurable metric export interval to prevent metrics from being generated for every Lambda invocation, reducing the number of metric datapoints generated. Relevant tests have been added to test the new exporting behavior and configuration changes. Furthermore, relevant documentation has been added documenting how to configure metric temporality and export intervals.