### PR TITLE
fix: java execution time Task.project invocation

### DIFF
--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -35,8 +35,10 @@ tasks {
     }
 }
 
+val runtimeClasspath = project.configurations["runtimeClasspath"]
+
 tasks.register("printOtelJavaInstrumentationVersion") {
     doLast {
-        println(project.configurations["runtimeClasspath"].resolvedConfiguration.resolvedArtifacts.find {  it.name == "opentelemetry-aws-lambda-events-2.2" }?.moduleVersion?.id?.version)
+        println(runtimeClasspath.resolvedConfiguration.resolvedArtifacts.find {  it.name == "opentelemetry-aws-lambda-events-2.2" }?.moduleVersion?.id?.version)
     }
 }

--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -35,10 +35,8 @@ tasks {
     }
 }
 
-val runtimeClasspath = project.configurations["runtimeClasspath"]
-
 tasks.register("printOtelJavaInstrumentationVersion") {
     doLast {
-        println(runtimeClasspath.resolvedConfiguration.resolvedArtifacts.find {  it.name == "opentelemetry-aws-lambda-events-2.2" }?.moduleVersion?.id?.version)
+        println(configurations.named("runtimeClasspath").get().resolvedConfiguration.resolvedArtifacts.find {  it.name == "opentelemetry-aws-lambda-events-2.2" }?.moduleVersion?.id?.version)
     }
 }


### PR DESCRIPTION
This fixes the ci failure we're experiencing during the release process for the java wrapper layer.