### PR TITLE
fix(nodejs): handle non-configurable exports from esbuild CJS bundles

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -36,6 +36,7 @@ import {
   Instrumentation,
   registerInstrumentations,
 } from '@opentelemetry/instrumentation';
+import type { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
 import {
   AwsInstrumentation,
   AwsSdkInstrumentationConfig,
@@ -331,20 +332,25 @@ async function createInstrumentations() {
   // We can't override init() because it's already called during construction (via enable()).
   // _onRequire is called lazily when modules are required, so this override takes effect
   // before the Lambda runtime loads the handler.
-  const originalOnRequire = (awsLambdaInstrumentation as any)._onRequire;
-  (awsLambdaInstrumentation as any)._onRequire = function (
-    module: any,
-    exports: any,
+  type OnRequireFn = <T>(
+    module: InstrumentationModuleDefinition,
+    exports: T,
     name: string,
-    basedir?: string,
-  ) {
-    return originalOnRequire.call(
-      this,
-      module,
-      makeExportsConfigurable(exports),
-      name,
-      basedir,
-    );
+    baseDir?: string | void,
+  ) => T;
+  const instrumentationWithOnRequire = awsLambdaInstrumentation as unknown as {
+    _onRequire: OnRequireFn;
+  };
+  const originalOnRequire = instrumentationWithOnRequire._onRequire.bind(
+    awsLambdaInstrumentation,
+  );
+  instrumentationWithOnRequire._onRequire = function <T>(
+    module: InstrumentationModuleDefinition,
+    exports: T,
+    name: string,
+    baseDir?: string | void,
+  ): T {
+    return originalOnRequire(module, makeExportsConfigurable(exports), name, baseDir);
   };
 
   return [

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -294,18 +294,66 @@ async function defaultConfigureInstrumentations() {
   return instrumentations;
 }
 
+// When esbuild bundles ESM to CJS format, it defines exports using non-configurable
+// accessor descriptors. OpenTelemetry's shimmer then fails with "Cannot redefine property"
+// when trying to wrap the handler. This replaces such exports with a new object that has
+// configurable data descriptors so shimmer can wrap them.
+// See: https://github.com/evanw/esbuild/issues/2199
+function makeExportsConfigurable<T>(moduleExports: T): T {
+  if (typeof moduleExports !== 'object' || moduleExports === null) {
+    return moduleExports;
+  }
+  const keys = Object.getOwnPropertyNames(moduleExports);
+  const descriptors = Object.getOwnPropertyDescriptors(moduleExports);
+  if (keys.every(key => descriptors[key].configurable)) {
+    return moduleExports;
+  }
+  const fixed = Object.create(Object.getPrototypeOf(moduleExports));
+  for (const key of keys) {
+    Object.defineProperty(fixed, key, {
+      value: moduleExports[key as keyof T],
+      writable: true,
+      enumerable: descriptors[key].enumerable,
+      configurable: true,
+    });
+  }
+  return fixed;
+}
+
 async function createInstrumentations() {
+  const awsLambdaInstrumentation = new AwsLambdaInstrumentation(
+    typeof configureLambdaInstrumentation === 'function'
+      ? configureLambdaInstrumentation({})
+      : {},
+  );
+
+  // Override _onRequire to fix non-configurable exports before patching.
+  // We can't override init() because it's already called during construction (via enable()).
+  // _onRequire is called lazily when modules are required, so this override takes effect
+  // before the Lambda runtime loads the handler.
+  const originalOnRequire = (awsLambdaInstrumentation as any)._onRequire;
+  (awsLambdaInstrumentation as any)._onRequire = function (
+    module: any,
+    exports: any,
+    name: string,
+    basedir?: string,
+  ) {
+    return originalOnRequire.call(
+      this,
+      module,
+      makeExportsConfigurable(exports),
+      name,
+      basedir,
+    );
+  };
+
   return [
     new AwsInstrumentation(
       typeof configureAwsInstrumentation === 'function'
         ? configureAwsInstrumentation({ suppressInternalInstrumentation: true })
         : { suppressInternalInstrumentation: true },
     ),
-    new AwsLambdaInstrumentation(
-      typeof configureLambdaInstrumentation === 'function'
-        ? configureLambdaInstrumentation({})
-        : {},
-    ),
+    awsLambdaInstrumentation,
     ...(typeof configureInstrumentations === 'function'
       ? configureInstrumentations()
       : await defaultConfigureInstrumentations()),

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -350,7 +350,12 @@ async function createInstrumentations() {
     name: string,
     baseDir?: string | void,
   ): T {
-    return originalOnRequire(module, makeExportsConfigurable(exports), name, baseDir);
+    return originalOnRequire(
+      module,
+      makeExportsConfigurable(exports),
+      name,
+      baseDir,
+    );
   };
 
   return [


### PR DESCRIPTION
## Summary
- When esbuild bundles ESM to CJS format, it defines exports using non-configurable accessor descriptors. OpenTelemetry's shimmer then fails with \`Cannot redefine property\` when trying to wrap the handler.
- Adds a \`makeExportsConfigurable()\` helper that replaces such exports with a new object having configurable data descriptors
- Monkey-patches \`AwsLambdaInstrumentation._onRequire\` to apply the fix before shimmer attempts patching

Fixes: #1781
See: https://github.com/evanw/esbuild/issues/2199


## Steps to reproduce

Create a handler that uses the same non-configurable export pattern that esbuild emits when bundling ESM to CJS:

```js
// index.js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
Object.defineProperty(exports, "handler", {
  enumerable: true,
  get: function () { return handler; }
  // intentionally no configurable: true — this is what esbuild produces
});

async function handler(event) {
  return { statusCode: 200, body: JSON.stringify({ message: "OK" }) };
}
```

Deploy as a Lambda with the OTel layer and `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler`:

```sh
zip handler.zip index.js

aws lambda create-function \
  --function-name otel-cjs-repro \
  --runtime nodejs20.x \
  --role <execution-role-arn> \
  --handler index.handler \
  --zip-file fileb://handler.zip \
  --layers arn:aws:lambda:<region>:184161586896:layer:opentelemetry-nodejs-0_20_0:1 \
  --environment "Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}"

aws lambda invoke --function-name otel-cjs-repro \
  --cli-binary-format raw-in-base64-out \
  --payload '{}' response.json && cat response.json
```

**Error with layer \`opentelemetry-nodejs-0_20_0:1\` (before fix):**
```json
{
  "errorType": "TypeError",
  "errorMessage": "Cannot redefine property: handler",
  "trace": [
    "TypeError: Cannot redefine property: handler",
    "    at Function.defineProperty (<anonymous>)",
    "    at v (/opt/wrapper.js:1:182016)",
    "    at b (/opt/wrapper.js:1:182467)",
    "    at T._wrap (/opt/wrapper.js:1:186433)",
    "    at Z.patch (/opt/wrapper.js:1:129045)",
    "    at /opt/wrapper.js:1:188360",
    "    at Array.reduce (<anonymous>)",
    "    at T._onRequire (/opt/wrapper.js:1:188154)",
    "    at n (/opt/wrapper.js:1:189147)",
    "    at Module.patchedRequire (/opt/node_modules/require-in-the-middle/index.js:302:28)"
  ]
}
```

**Root cause:** esbuild emits exports as non-configurable accessor descriptors (see [esbuild#2199](https://github.com/evanw/esbuild/issues/2199)), so \`Object.defineProperty\` in shimmer fails when trying to wrap the handler.

## Results

| Layer | Invocation result |
|-------|-------------------|
| \`opentelemetry-nodejs-0_20_0:1\` (without fix) | \`TypeError: Cannot redefine property: handler\` ❌ |
| Custom layer built from this PR (with fix) | \`{"statusCode":200,"body":"{\"message\":\"OK\"}"}\` ✅ |

## Test plan
- [x] Manually reproduced the error using a plain CJS handler with non-configurable exports + public layer \`opentelemetry-nodejs-0_20_0:1\`
- [x] Verified fix resolves the error with the same handler + a layer built from this PR
- [ ] Verify existing ESM and plain CJS handlers still work correctly