### PR TITLE
feat(nodejs): drop the trailing comma from OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -5,7 +5,11 @@ set -ef -o pipefail
 export NODE_OPTIONS="${NODE_OPTIONS} --import /opt/init.mjs"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
-  export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+  if [[ -n "$OTEL_RESOURCE_ATTRIBUTES" ]]; then
+    export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+  else
+    export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME}"
+  fi
 fi
 
 if [[ -z "$OTEL_PROPAGATORS" ]]; then


### PR DESCRIPTION
For the [@opentelemetry/resources](https://github.com/open-telemetry/opentelemetry-js) upgrade to `2.6.0` in #2165 there's a breaking change regarding parsing of the `OTEL_RESOURCE_ATTRIBUTES` and:

> Per spec, any parsing error results in ignoring the entire environment variable.

Due to the current code leaving a trailing comma in the `$OTEL_RESOURCE_ATTRIBUTES` value in the case where the user has it unset or empty, specifically this code in the upstream package would lead to an error being thrown:
https://github.com/open-telemetry/opentelemetry-js/blob/425bbfe4b341de82a07f16086a69787b31e97b9d/packages/opentelemetry-resources/src/detectors/EnvDetector.ts#L76-L92