### PR TITLE
fix: publish layers to more AWS regions

### DIFF
--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -18,18 +18,34 @@ on:
         type: choice
         options:
           - all
+          - af-south-1
+          - ap-east-1
+          - ap-east-2
           - ap-northeast-1
           - ap-northeast-2
           - ap-south-1
+          - ap-south-2
           - ap-southeast-1
           - ap-southeast-2
+          - ap-southeast-3
+          - ap-southeast-4
+          - ap-southeast-5
+          - ap-southeast-6
+          - ap-southeast-7
           - ca-central-1
           - ca-west-1
           - eu-central-1
+          - eu-central-2
           - eu-north-1
+          - eu-south-1
+          - eu-south-2
           - eu-west-1
           - eu-west-2
           - eu-west-3
+          - il-central-1
+          - me-central-1
+          - me-south-1
+          - mx-central-1
           - sa-east-1
           - us-east-1
           - us-east-2
@@ -112,7 +128,7 @@ jobs:
           fi
           aws_regions=''
           if [ ${{ github.event.inputs.aws-region }} == 'all' ]; then
-            aws_regions='["ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "ca-west-1", "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"]'
+            aws_regions='["af-south-1", "ap-east-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4", "ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3", "il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"]'
           else
             aws_regions='["${{ github.event.inputs.aws-region }}"]'
           fi

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -69,18 +69,34 @@ jobs:
           - amd64
           - arm64
         aws_region:
+          - af-south-1
+          - ap-east-1
+          - ap-east-2
           - ap-northeast-1
           - ap-northeast-2
           - ap-south-1
+          - ap-south-2
           - ap-southeast-1
           - ap-southeast-2
+          - ap-southeast-3
+          - ap-southeast-4
+          - ap-southeast-5
+          - ap-southeast-6
+          - ap-southeast-7
           - ca-central-1
           - ca-west-1
           - eu-central-1
+          - eu-central-2
           - eu-north-1
+          - eu-south-1
+          - eu-south-2
           - eu-west-1
           - eu-west-2
           - eu-west-3
+          - il-central-1
+          - me-central-1
+          - me-south-1
+          - mx-central-1
           - sa-east-1
           - us-east-1
           - us-east-2

--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -87,18 +87,34 @@ jobs:
     strategy:
       matrix:
         aws_region: 
+          - af-south-1
+          - ap-east-1
+          - ap-east-2
           - ap-northeast-1
           - ap-northeast-2
           - ap-south-1
+          - ap-south-2
           - ap-southeast-1
           - ap-southeast-2
+          - ap-southeast-3
+          - ap-southeast-4
+          - ap-southeast-5
+          - ap-southeast-6
+          - ap-southeast-7
           - ca-central-1
           - ca-west-1
           - eu-central-1
+          - eu-central-2
           - eu-north-1
+          - eu-south-1
+          - eu-south-2
           - eu-west-1
           - eu-west-2
           - eu-west-3
+          - il-central-1
+          - me-central-1
+          - me-south-1
+          - mx-central-1
           - sa-east-1
           - us-east-1
           - us-east-2
@@ -125,18 +141,34 @@ jobs:
     strategy:
       matrix:
         aws_region:
+          - af-south-1
+          - ap-east-1
+          - ap-east-2
           - ap-northeast-1
           - ap-northeast-2
           - ap-south-1
+          - ap-south-2
           - ap-southeast-1
           - ap-southeast-2
+          - ap-southeast-3
+          - ap-southeast-4
+          - ap-southeast-5
+          - ap-southeast-6
+          - ap-southeast-7
           - ca-central-1
           - ca-west-1
           - eu-central-1
+          - eu-central-2
           - eu-north-1
+          - eu-south-1
+          - eu-south-2
           - eu-west-1
           - eu-west-2
           - eu-west-3
+          - il-central-1
+          - me-central-1
+          - me-south-1
+          - mx-central-1
           - sa-east-1
           - us-east-1
           - us-east-2

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -72,18 +72,34 @@ jobs:
     strategy:
       matrix:
         aws_region:
+          - af-south-1
+          - ap-east-1
+          - ap-east-2
           - ap-northeast-1
           - ap-northeast-2
           - ap-south-1
+          - ap-south-2
           - ap-southeast-1
           - ap-southeast-2
+          - ap-southeast-3
+          - ap-southeast-4
+          - ap-southeast-5
+          - ap-southeast-6
+          - ap-southeast-7
           - ca-central-1
           - ca-west-1
           - eu-central-1
+          - eu-central-2
           - eu-north-1
+          - eu-south-1
+          - eu-south-2
           - eu-west-1
           - eu-west-2
           - eu-west-3
+          - il-central-1
+          - me-central-1
+          - me-south-1
+          - mx-central-1
           - sa-east-1
           - us-east-1
           - us-east-2

--- a/.github/workflows/release-layer-python.yml
+++ b/.github/workflows/release-layer-python.yml
@@ -79,18 +79,34 @@ jobs:
     strategy:
       matrix:
         aws_region: 
+          - af-south-1
+          - ap-east-1
+          - ap-east-2
           - ap-northeast-1
           - ap-northeast-2
           - ap-south-1
+          - ap-south-2
           - ap-southeast-1
           - ap-southeast-2
+          - ap-southeast-3
+          - ap-southeast-4
+          - ap-southeast-5
+          - ap-southeast-6
+          - ap-southeast-7
           - ca-central-1
           - ca-west-1
           - eu-central-1
+          - eu-central-2
           - eu-north-1
+          - eu-south-1
+          - eu-south-2
           - eu-west-1
           - eu-west-2
           - eu-west-3
+          - il-central-1
+          - me-central-1
+          - me-south-1
+          - mx-central-1
           - sa-east-1
           - us-east-1
           - us-east-2

--- a/.github/workflows/release-layer-ruby.yml
+++ b/.github/workflows/release-layer-ruby.yml
@@ -71,18 +71,34 @@ jobs:
     strategy:
       matrix:
         aws_region: 
+          - af-south-1
+          - ap-east-1
+          - ap-east-2
           - ap-northeast-1
           - ap-northeast-2
           - ap-south-1
+          - ap-south-2
           - ap-southeast-1
           - ap-southeast-2
+          - ap-southeast-3
+          - ap-southeast-4
+          - ap-southeast-5
+          - ap-southeast-6
+          - ap-southeast-7
           - ca-central-1
           - ca-west-1
           - eu-central-1
+          - eu-central-2
           - eu-north-1
+          - eu-south-1
+          - eu-south-2
           - eu-west-1
           - eu-west-2
           - eu-west-3
+          - il-central-1
+          - me-central-1
+          - me-south-1
+          - mx-central-1
           - sa-east-1
           - us-east-1
           - us-east-2

--- a/collector/README.md
+++ b/collector/README.md
@@ -71,7 +71,7 @@ After that, you can run the `Publish Collector Lambda Layer` workflow to build t
   Available options are `all`, `amd64` and `arm64`.
   The default value is `all` which builds and publishes layer for both of the `amd64` and `arm64` architectures.
 - Specify the AWS region(s) where the collector Lambda layer will be published to via the `AWS Region(s) where layer will be published` input.
-  Available options are `all`, `ap-northeast-1`, `ap-northeast-2`, `ap-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ca-central-1`, `ca-west-1`, `eu-central-1`, `eu-north-1`, `eu-west-1`, `eu-west-2`, `eu-west-3`, `sa-east-1`, `us-east-1`, `us-east-2`, `us-west-1`, `us-west-2`.
+  Available options are `all`, `af-south-1`, `ap-east-1`, `ap-east-2`, `ap-northeast-1`, `ap-northeast-2`, `ap-south-1`, `ap-south-2`, `ap-southeast-1`, `ap-southeast-2`, `ap-southeast-3`, `ap-southeast-4`, `ap-southeast-5`, `ap-southeast-6`, `ap-southeast-7`, `ca-central-1`, `ca-west-1`, `eu-central-1`, `eu-central-2`, `eu-north-1`, `eu-south-1`, `eu-south-2`, `eu-west-1`, `eu-west-2`, `eu-west-3`, `il-central-1`, `me-central-1`, `me-south-1`, `mx-central-1`, `sa-east-1`, `us-east-1`, `us-east-2`, `us-west-1`, `us-west-2`.
   The default value is `all` which publishes layer to all the defined AWS regions mentioned above.
 - Specify the AWS IAM Role ARN to be assumed for publishing layer via the `AWS IAM Role ARN to be assumed for publishing layer` input.
   This is the ARN of the AWS IAM Role you have taken from the `RoleARN` output variable of the created AWS CloudFormation stack above.


### PR DESCRIPTION
fixes: #2187

Note that those regions must be enabled manually 
(see: https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html on how to proceed)

It seems that `ca-west-1` was already there!

Let me know if that sounds good to you :)
Thanks!
