### PR TITLE
fix: dependabot

### DIFF
--- a/nodejs/tsconfig.base.json
+++ b/nodejs/tsconfig.base.json
@@ -12,6 +12,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "pretty": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
This PR fixes the issue in https://github.com/open-telemetry/opentelemetry-lambda/pull/2195 where CI for nodejs is failing with:
```
...
tsc --build tsconfig.json
Error: ../../node_modules/@types/eslint-scope/index.d.ts(7,5): error TS2416: Property 'scopes' in type 'ScopeManager' is not assignable to the same property in base type 'ScopeManager'.
...
```

This error is raised when we type check dependencies. `@types/eslint-scope` is brought via `webpack` and I think we don't really care about type checking this that's why I introduced the `skipLibCheck` where typescript skip validation on 3rd pary lib (see: https://www.typescriptlang.org/tsconfig/#skipLibCheck)

From the doc, it seems that it's exactly the perfect use case to use it.
```
Another possibility is when you are migrating between TypeScript releases and the changes cause breakages in node_modules and the JS standard libraries which you do not want to deal with during the TypeScript update.
```

The target of this PR is the dependabot PR so CI should be green here if the fix is working :)