### PR TITLE
chore(nodejs): exclude test files from webpack ts compilation scope

### DIFF
--- a/nodejs/packages/layer/tsconfig.webpack.json
+++ b/nodejs/packages/layer/tsconfig.webpack.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "types": ["node", "mocha", "sinon"]
+    "types": ["node"]
   },
   "include": [
-    "src/**/*.ts",
-    "test/**/*.ts"
+    "src/**/*.ts"
   ]
 }


### PR DESCRIPTION
For the ts upgrade to v6 in #2222 I had to specify the `mocha` and `sinon` types in tsconfig since the test files were included in the compilation scope there. This tsconfig file however is specifically for compilation of the production code that gets bundled by webpack so it makes no sense to include the test files in the compilation scope there.