### PR TITLE
fix(collector) add nil check before consuming traces in telemetryAPIReceiver

### DIFF
--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -266,12 +266,14 @@ func (r *telemetryAPIReceiver) httpHandler(w http.ResponseWriter, req *http.Requ
 			if len(r.lastPlatformStartTime) > 0 && len(r.lastPlatformEndTime) > 0 {
 				if record, ok := el.Record.(map[string]any); ok {
 					if td, err := r.createPlatformInitSpan(record, r.lastPlatformStartTime, r.lastPlatformEndTime); err == nil {
-						err := r.nextTraces.ConsumeTraces(context.Background(), td)
-						if err == nil {
-							r.lastPlatformEndTime = ""
-							r.lastPlatformStartTime = ""
-						} else {
-							r.logger.Error("error receiving traces", zap.Error(err))
+						if r.nextTraces != nil {
+							err := r.nextTraces.ConsumeTraces(context.Background(), td)
+							if err == nil {
+								r.lastPlatformEndTime = ""
+								r.lastPlatformStartTime = ""
+							} else {
+								r.logger.Error("error receiving traces", zap.Error(err))
+							}
 						}
 					}
 				}


### PR DESCRIPTION
In case the collector is configured without a traces pipeline this currently results in a panic since `r.nextTraces` would always be nil. This regression was accidentally introduced in #2066 and was missed during review.