### PR TITLE
Add MAKEFLAGS=-j$(nproc) to test and build-layer jobs

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -20,6 +20,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      MAKEFLAGS: -j$(nproc)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -24,6 +24,8 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    env:
+      MAKEFLAGS: -j$(nproc)
     needs: create-release
     strategy:
       matrix:


### PR DESCRIPTION
Parallelizes make targets across Go modules in collector, reducing CI wall time by up to 2-3x on multi-core runners.

This PR speeds up the collector CI test job by enabling parallel `make` execution.

The collector test workflow currently runs `make gotidy` and `make gotest` serially through the default Make behavior. Setting `MAKEFLAGS: -j$(nproc)` lets Make use the available runner CPU cores where the Makefile has independent work to execute.

