### PR TITLE
fix(nodejs): normalize exporter env values before parsing

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -108,6 +108,18 @@ function getActiveInstrumentations(): Set<string> {
   return instrumentationSet;
 }
 
+function getNormalizedEnvList(name: string): string[] {
+  const value = process.env[name];
+  if (value == null || value.trim() === '') {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map(item => item.toLowerCase().trim())
+    .filter(item => item !== '');
+}
+
 async function defaultConfigureInstrumentations() {
   const instrumentations = [];
   const activeInstrumentations = getActiveInstrumentations();
@@ -283,10 +295,10 @@ async function createInstrumentations() {
 }
 
 function getPropagator(): TextMapPropagator {
-  if (
-    process.env.OTEL_PROPAGATORS == null ||
-    process.env.OTEL_PROPAGATORS.trim() === ''
-  ) {
+  const propagatorsFromEnv = Array.from(
+    new Set(getNormalizedEnvList('OTEL_PROPAGATORS')),
+  );
+  if (propagatorsFromEnv.length === 0) {
     return new CompositePropagator({
       propagators: [
         new W3CTraceContextPropagator(),
@@ -294,13 +306,6 @@ function getPropagator(): TextMapPropagator {
       ],
     });
   }
-  const propagatorsFromEnv = Array.from(
-    new Set(
-      process.env.OTEL_PROPAGATORS?.split(',').map(value =>
-        value.toLowerCase().trim(),
-      ),
-    ),
-  );
   const propagators = propagatorsFromEnv.flatMap(propagatorName => {
     if (propagatorName === 'none') {
       diag.info(
@@ -321,13 +326,11 @@ function getPropagator(): TextMapPropagator {
 }
 
 function getExportersFromEnv(): SpanExporter[] | null {
-  if (
-    process.env.OTEL_TRACES_EXPORTER == null ||
-    process.env.OTEL_TRACES_EXPORTER.trim() === ''
-  ) {
+  const exporterNames = getNormalizedEnvList('OTEL_TRACES_EXPORTER');
+  if (exporterNames.length === 0) {
     return [];
   }
-  if (process.env.OTEL_TRACES_EXPORTER.includes('none')) {
+  if (exporterNames.includes('none')) {
     return null;
   }
 
@@ -336,8 +339,7 @@ function getExportersFromEnv(): SpanExporter[] | null {
     ['console', () => new ConsoleSpanExporter()],
   ]);
   const exporters: SpanExporter[] = [];
-  process.env.OTEL_TRACES_EXPORTER.split(',').map(exporterName => {
-    exporterName = exporterName.toLowerCase().trim();
+  exporterNames.map(exporterName => {
     const exporter = stringToExporter.get(exporterName);
     if (exporter) {
       exporters.push(exporter());
@@ -409,7 +411,7 @@ async function initializeTracerProvider(
 async function initializeMeterProvider(
   resource: Resource,
 ): Promise<unknown | undefined> {
-  if (process.env.OTEL_METRICS_EXPORTER === 'none') {
+  if (getNormalizedEnvList('OTEL_METRICS_EXPORTER').includes('none')) {
     return;
   }
 
@@ -450,7 +452,7 @@ async function initializeMeterProvider(
 async function initializeLoggerProvider(
   resource: Resource,
 ): Promise<unknown | undefined> {
-  if (process.env.OTEL_LOGS_EXPORTER === 'none') {
+  if (getNormalizedEnvList('OTEL_LOGS_EXPORTER').includes('none')) {
     return;
   }
 

--- a/nodejs/packages/layer/test/wrapper.spec.ts
+++ b/nodejs/packages/layer/test/wrapper.spec.ts
@@ -2,11 +2,13 @@ import { init, wrap, unwrap } from '../src/wrapper';
 
 import {
   defaultTextMapGetter,
+  metrics,
   ROOT_CONTEXT,
   TextMapPropagator,
   trace,
   TraceFlags,
 } from '@opentelemetry/api';
+import { logs } from '@opentelemetry/api-logs';
 import type { AwsSdkInstrumentationConfig } from '@opentelemetry/instrumentation-aws-sdk';
 import { TRACE_PARENT_HEADER } from '@opentelemetry/core';
 import { AWSXRAY_TRACE_ID_HEADER } from '@opentelemetry/propagator-aws-xray';
@@ -191,6 +193,8 @@ describe('wrapper', async () => {
 
   describe('exporters', () => {
     let providerSpy: SinonSpy;
+    let meterProviderSpy: SinonSpy;
+    let loggerProviderSpy: SinonSpy;
 
     before(() => {
       // TODO: Does this belong here
@@ -199,10 +203,14 @@ describe('wrapper', async () => {
 
     beforeEach(() => {
       providerSpy = spy(NodeTracerProvider.prototype, 'register');
+      meterProviderSpy = spy(metrics, 'setGlobalMeterProvider');
+      loggerProviderSpy = spy(logs, 'setGlobalLoggerProvider');
     });
 
     afterEach(() => {
       providerSpy.restore();
+      meterProviderSpy.restore();
+      loggerProviderSpy.restore();
     });
 
     const testConfiguredExporter = async (
@@ -236,6 +244,30 @@ describe('wrapper', async () => {
         ['console', 'otlp'],
         [ConsoleSpanExporter, OTLPTraceExporter],
       );
+    });
+
+    it('disables traces for case-insensitive none values', async () => {
+      process.env.OTEL_TRACES_EXPORTER = ' NoNe ';
+
+      await wrap();
+
+      assert.equal(providerSpy.called, false);
+    });
+
+    it('disables metrics for case-insensitive none values', async () => {
+      process.env.OTEL_METRICS_EXPORTER = ' NoNe ';
+
+      await wrap();
+
+      assert.equal(meterProviderSpy.called, false);
+    });
+
+    it('disables logs for case-insensitive none values', async () => {
+      process.env.OTEL_LOGS_EXPORTER = ' NoNe ';
+
+      await wrap();
+
+      assert.equal(loggerProviderSpy.called, false);
     });
   });
 });


### PR DESCRIPTION
`OTEL_*_EXPORTER=none` should still work if the value shows up as `NoNe` or with extra spaces. In Lambda thats pretty easy to hit, env vars are just literal strings.

Repro:
1. On current `main`, set `OTEL_TRACES_EXPORTER=' NoNe '`.
2. Call `wrap()` in the NodeJS layer.
3. The tracer provider still registers, and it logs `Invalid exporter "none"`.

This normalizes exporter env values before parsing, so `none` is handled case insensitively for traces, metrics, and logs. Added regression tests too.

Checks:
`npm test --workspace @opentelemetry-lambda/sdk-layer`
