### PR TITLE
feat(collector): decouple extension from internal log level

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-lambda/collector/internal/confmap/converter/disablequeuedretryconverter"
+	"github.com/open-telemetry/opentelemetry-lambda/collector/internal/logging"
 )
 
 // Collector runs a single otelcol as a go routine within the
@@ -45,6 +46,7 @@ type Collector struct {
 	stopped   bool
 	logger    *zap.Logger
 	version   string
+	coreFunc  logging.CoreFunc
 }
 
 func getConfig(logger *zap.Logger) string {
@@ -88,6 +90,7 @@ func NewCollector(logger *zap.Logger, factories otelcol.Factories, version strin
 		cfgProSet: cfgSet,
 		logger:    logger,
 		version:   version,
+		coreFunc:  logging.NewCore,
 	}
 	return col
 }
@@ -103,18 +106,8 @@ func (c *Collector) Start(ctx context.Context) error {
 		Factories: func() (otelcol.Factories, error) {
 			return c.factories, nil
 		},
-		// TODO: fully decouple extension and collector log levels so that
-		// OPENTELEMETRY_EXTENSION_LOG_LEVEL only affects extension logs.
 		LoggingOptions: []zap.Option{zap.WrapCore(func(collectorCore zapcore.Core) zapcore.Core {
-			extensionCore := c.logger.Core()
-			if zapcore.LevelOf(collectorCore) == zapcore.InfoLevel {
-				return extensionCore
-			}
-			increased, err := zapcore.NewIncreaseLevelCore(extensionCore, collectorCore)
-			if err != nil {
-				return extensionCore
-			}
-			return increased
+			return c.coreFunc(collectorCore)
 		})},
 	}
 	var err error

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -46,7 +46,7 @@ type Collector struct {
 	stopped   bool
 	logger    *zap.Logger
 	version   string
-	coreFunc  logging.CoreFunc
+	coreFunc  func(zapcore.LevelEnabler) zapcore.Core
 }
 
 func getConfig(logger *zap.Logger) string {

--- a/collector/internal/collector/collector_test.go
+++ b/collector/internal/collector/collector_test.go
@@ -29,28 +29,19 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestCollectorConfigLogLevelIsOverridden(t *testing.T) {
+func TestCollectorConfigLogLevelSuppressesCollectorInfoLogs(t *testing.T) {
 	t.Setenv("OPENTELEMETRY_COLLECTOR_CONFIG_URI", "file:testdata/config-error-level.yaml")
 
-	receivers, err := otelcol.MakeFactoryMap(receivertest.NewNopFactory())
-	require.NoError(t, err)
-	exporters, err := otelcol.MakeFactoryMap(exportertest.NewNopFactory())
-	require.NoError(t, err)
-
-	factories := otelcol.Factories{
-		Receivers: receivers,
-		Exporters: exporters,
-		Telemetry: otelconftelemetry.NewFactory(),
+	collectorLogs := &observer.ObservedLogs{}
+	collector := NewCollector(zap.NewNop(), testFactories(t), "test")
+	collector.coreFunc = func(levelEnabler zapcore.LevelEnabler) zapcore.Core {
+		var collectorObservedCore zapcore.Core
+		collectorObservedCore, collectorLogs = observer.New(levelEnabler)
+		return collectorObservedCore
 	}
 
-	// Use a nop logger so extension logs don't end up in our observer
-	collector := NewCollector(zap.NewNop(), factories, "test")
-	// Replace collector logger with an observed core at INFO level.
-	collectorObservedCore, collectorLogs := observer.New(zapcore.InfoLevel)
-	collector.logger = zap.New(collectorObservedCore)
-
 	ctx := context.Background()
-	err = collector.Start(ctx)
+	err := collector.Start(ctx)
 	require.NoError(t, err)
 
 	err = collector.Stop()
@@ -60,4 +51,64 @@ func TestCollectorConfigLogLevelIsOverridden(t *testing.T) {
 	infoLogs := collectorLogs.FilterLevelExact(zapcore.InfoLevel).All()
 	assert.Empty(t, infoLogs,
 		"INFO logs from the collector should be suppressed when config sets level: error")
+}
+
+func TestExtensionLogLevelDoesNotSuppressCollectorLogs(t *testing.T) {
+	t.Setenv("OPENTELEMETRY_COLLECTOR_CONFIG_URI", "file:testdata/config-info-level.yaml")
+
+	extensionObservedCore, extensionLogs := observer.New(zapcore.ErrorLevel)
+	collectorLogs := &observer.ObservedLogs{}
+	collector := NewCollector(zap.New(extensionObservedCore), testFactories(t), "test")
+	collector.coreFunc = func(levelEnabler zapcore.LevelEnabler) zapcore.Core {
+		var collectorObservedCore zapcore.Core
+		collectorObservedCore, collectorLogs = observer.New(levelEnabler)
+		return collectorObservedCore
+	}
+
+	ctx := context.Background()
+	err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	err = collector.Stop()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, collectorLogs.FilterLevelExact(zapcore.InfoLevel).All(),
+		"INFO logs from the collector should be emitted when collector config sets level: info")
+	assert.Empty(t, extensionLogs.All(), "collector logs should not be written through the extension logger core")
+}
+
+func TestCollectorLogLevelDoesNotSuppressExtensionLogs(t *testing.T) {
+	t.Setenv("OPENTELEMETRY_COLLECTOR_CONFIG_URI", "file:testdata/config-error-level.yaml")
+
+	extensionObservedCore, extensionLogs := observer.New(zapcore.InfoLevel)
+	collector := NewCollector(zap.New(extensionObservedCore), testFactories(t), "test")
+	collector.coreFunc = func(levelEnabler zapcore.LevelEnabler) zapcore.Core {
+		collectorObservedCore, _ := observer.New(levelEnabler)
+		return collectorObservedCore
+	}
+
+	ctx := context.Background()
+	err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	collector.logger.Info("extension log")
+
+	err = collector.Stop()
+	require.NoError(t, err)
+
+	assert.Len(t, extensionLogs.FilterMessage("extension log").All(), 1,
+		"extension logs should be controlled by the extension logger, not collector config")
+}
+
+func testFactories(t *testing.T) otelcol.Factories {
+	receivers, err := otelcol.MakeFactoryMap(receivertest.NewNopFactory())
+	require.NoError(t, err)
+	exporters, err := otelcol.MakeFactoryMap(exportertest.NewNopFactory())
+	require.NoError(t, err)
+
+	return otelcol.Factories{
+		Receivers: receivers,
+		Exporters: exporters,
+		Telemetry: otelconftelemetry.NewFactory(),
+	}
 }

--- a/collector/internal/collector/testdata/config-info-level.yaml
+++ b/collector/internal/collector/testdata/config-info-level.yaml
@@ -1,0 +1,14 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    traces:
+      receivers: [nop]
+      exporters: [nop]

--- a/collector/internal/logging/logger.go
+++ b/collector/internal/logging/logger.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const extensionLogLevelEnvVar = "OPENTELEMETRY_EXTENSION_LOG_LEVEL"
+
+type CoreFunc func(zapcore.LevelEnabler) zapcore.Core
+
+var (
+	encoderConfig = zap.NewProductionEncoderConfig()
+	stdoutSyncer  = zapcore.Lock(zapcore.AddSync(os.Stdout))
+)
+
+func NewLogger() *zap.Logger {
+	return newLogger(os.Getenv(extensionLogLevelEnvVar), NewCore)
+}
+
+func NewCore(levelEnabler zapcore.LevelEnabler) zapcore.Core {
+	return zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), stdoutSyncer, levelEnabler)
+}
+
+func newLogger(envLvl string, coreFunc CoreFunc) *zap.Logger {
+	lvl := zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	var err error
+	if envLvl != "" {
+		var userLvl zap.AtomicLevel
+		userLvl, err = zap.ParseAtomicLevel(envLvl)
+		if err == nil {
+			lvl = userLvl
+		}
+	}
+
+	l := zap.New(coreFunc(lvl))
+
+	if err != nil && envLvl != "" {
+		l.Warn("unable to parse log level from environment", zap.Error(err))
+	}
+
+	return l
+}

--- a/collector/internal/logging/logger.go
+++ b/collector/internal/logging/logger.go
@@ -23,37 +23,35 @@ import (
 
 const extensionLogLevelEnvVar = "OPENTELEMETRY_EXTENSION_LOG_LEVEL"
 
-type CoreFunc func(zapcore.LevelEnabler) zapcore.Core
-
 var (
 	encoderConfig = zap.NewProductionEncoderConfig()
 	stdoutSyncer  = zapcore.Lock(zapcore.AddSync(os.Stdout))
 )
 
 func NewLogger() *zap.Logger {
-	return newLogger(os.Getenv(extensionLogLevelEnvVar), NewCore)
+	lvl, err := parseLevel(os.Getenv(extensionLogLevelEnvVar))
+
+	l := zap.New(NewCore(lvl))
+
+	if err != nil {
+		l.Warn("unable to parse log level from environment", zap.Error(err))
+	}
+	return l
 }
 
 func NewCore(levelEnabler zapcore.LevelEnabler) zapcore.Core {
 	return zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), stdoutSyncer, levelEnabler)
 }
 
-func newLogger(envLvl string, coreFunc CoreFunc) *zap.Logger {
-	lvl := zap.NewAtomicLevelAt(zapcore.InfoLevel)
-	var err error
-	if envLvl != "" {
-		var userLvl zap.AtomicLevel
-		userLvl, err = zap.ParseAtomicLevel(envLvl)
-		if err == nil {
-			lvl = userLvl
-		}
+// parseLevel resolves the extension log level from the env var value,
+// falling back to INFO and returning an error if the value is invalid.
+func parseLevel(envLvl string) (zap.AtomicLevel, error) {
+	if envLvl == "" {
+		return zap.NewAtomicLevelAt(zapcore.InfoLevel), nil
 	}
-
-	l := zap.New(coreFunc(lvl))
-
-	if err != nil && envLvl != "" {
-		l.Warn("unable to parse log level from environment", zap.Error(err))
+	userLvl, err := zap.ParseAtomicLevel(envLvl)
+	if err != nil {
+		return zap.NewAtomicLevelAt(zapcore.InfoLevel), err
 	}
-
-	return l
+	return userLvl, nil
 }

--- a/collector/internal/logging/logger.go
+++ b/collector/internal/logging/logger.go
@@ -34,7 +34,7 @@ func NewLogger() *zap.Logger {
 	l := zap.New(NewCore(lvl))
 
 	if err != nil {
-		l.Warn("unable to parse log level from environment", zap.Error(err))
+		l.Warn("unable to parse log level from environment, falling back to default log level", zap.Error(err), zap.Stringer("default_level", lvl))
 	}
 	return l
 }

--- a/collector/internal/logging/logger_test.go
+++ b/collector/internal/logging/logger_test.go
@@ -18,34 +18,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestNewLoggerWarnsForInvalidExtensionLogLevel(t *testing.T) {
-	observedCore, logs := observer.New(zapcore.DebugLevel)
-
-	logger := newLogger("not-a-level", func(zapcore.LevelEnabler) zapcore.Core {
-		return observedCore
-	})
-
-	logger.Info("extension info")
-
-	assert.Len(t, logs.FilterMessage("unable to parse log level from environment").All(), 1)
-	assert.Len(t, logs.FilterMessage("extension info").All(), 1)
+func TestParseLevelDefaultsToInfoWhenUnset(t *testing.T) {
+	lvl, err := parseLevel("")
+	require.NoError(t, err)
+	assert.Equal(t, zapcore.InfoLevel, lvl.Level())
 }
 
-func TestNewLoggerAppliesValidExtensionLogLevel(t *testing.T) {
-	logs := &observer.ObservedLogs{}
-	logger := newLogger("error", func(levelEnabler zapcore.LevelEnabler) zapcore.Core {
-		observedCore, observedLogs := observer.New(levelEnabler)
-		logs = observedLogs
-		return observedCore
-	})
+func TestParseLevelAppliesValidLevel(t *testing.T) {
+	lvl, err := parseLevel("error")
+	require.NoError(t, err)
+	assert.Equal(t, zapcore.ErrorLevel, lvl.Level())
+}
 
-	logger.Info("extension info")
-	logger.Error("extension error")
-
-	assert.Empty(t, logs.FilterMessage("extension info").All())
-	assert.Len(t, logs.FilterMessage("extension error").All(), 1)
+func TestParseLevelFallsBackToInfoAndErrorsOnInvalid(t *testing.T) {
+	lvl, err := parseLevel("not-a-level")
+	require.Error(t, err)
+	assert.Equal(t, zapcore.InfoLevel, lvl.Level(), "should fall back to INFO")
 }

--- a/collector/internal/logging/logger_test.go
+++ b/collector/internal/logging/logger_test.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNewLoggerWarnsForInvalidExtensionLogLevel(t *testing.T) {
+	observedCore, logs := observer.New(zapcore.DebugLevel)
+
+	logger := newLogger("not-a-level", func(zapcore.LevelEnabler) zapcore.Core {
+		return observedCore
+	})
+
+	logger.Info("extension info")
+
+	assert.Len(t, logs.FilterMessage("unable to parse log level from environment").All(), 1)
+	assert.Len(t, logs.FilterMessage("extension info").All(), 1)
+}
+
+func TestNewLoggerAppliesValidExtensionLogLevel(t *testing.T) {
+	logs := &observer.ObservedLogs{}
+	logger := newLogger("error", func(levelEnabler zapcore.LevelEnabler) zapcore.Core {
+		observedCore, observedLogs := observer.New(levelEnabler)
+		logs = observedLogs
+		return observedCore
+	})
+
+	logger.Info("extension info")
+	logger.Error("extension error")
+
+	assert.Empty(t, logs.FilterMessage("extension info").All())
+	assert.Len(t, logs.FilterMessage("extension error").All(), 1)
+}

--- a/collector/main.go
+++ b/collector/main.go
@@ -18,14 +18,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-lambda/collector/internal/lifecycle"
+	"github.com/open-telemetry/opentelemetry-lambda/collector/internal/logging"
 )
 
 var (
@@ -44,7 +43,7 @@ func main() {
 		return
 	}
 
-	logger := initLogger()
+	logger := logging.NewLogger()
 	logger.Info("Launching OpenTelemetry Lambda extension", zap.String("version", Version))
 
 	ctx, lm := lifecycle.NewManager(context.Background(), logger, Version)
@@ -54,26 +53,4 @@ func main() {
 
 	// Will block until shutdown event is received or cancelled via the context.
 	logger.Info("done", zap.Error(lm.Run(ctx)))
-}
-
-func initLogger() *zap.Logger {
-	lvl := zap.NewAtomicLevelAt(zapcore.InfoLevel)
-	envLvl := os.Getenv("OPENTELEMETRY_EXTENSION_LOG_LEVEL")
-	// When not set, Getenv returns empty string
-	var err error
-	if envLvl != "" {
-		var userLvl zap.AtomicLevel
-		userLvl, err = zap.ParseAtomicLevel(envLvl)
-		if err == nil {
-			lvl = userLvl
-		}
-	}
-
-	l := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), os.Stdout, lvl))
-
-	if err != nil && envLvl != "" {
-		l.Warn("unable to parse log level from environment", zap.Error(err))
-	}
-
-	return l
 }


### PR DESCRIPTION
Follow-up to #2243 - this time removing the "heuristic" fallback that was included there. Fully decoupling the log levels, and some refactoring to keep the logger creation in one place. Since we want to keep output format (JSON encoding, emitted to STDOUT) aligned and avoid having to update that in 2 places.