### PR TITLE
chore: More renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,23 @@
       "enabled": true
     },
     {
+      groupName: "opentelemetry-deps-dotnet",
+      labels: ["dotnet"],
+      matchDepNames: ["OpenTelemetry.*"],
+      matchCategories: [
+        'dotnet'
+      ],
+      schedule: ["before 8am on Monday"],
+    },
+    {
+      groupName: "dotnet-other",
+      labels: ["dotnet"],
+      matchCategories: [
+        'dotnet'
+      ],
+      schedule: ["before 8am on Monday"],
+    },
+    {
       groupName: "opentelemetry-deps-collector",
       labels: ["go"],
       matchDepNames: ["*opentelemetry*"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -191,7 +191,7 @@
   lockFileMaintenance: {
     enabled: true,
     schedule: [
-      'before 8am on Monday',
+      'before 8am on Wednesday',
     ],
   },
   semanticCommits: 'enabled',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -107,6 +107,8 @@
     enabled: true,
     schedule: ["before 8am on Monday"],
   },
+  semanticCommits: 'enabled',
   semanticCommitType: "build",
+  semanticCommitScope: "deps",
   labels: ["dependencies"],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,8 @@
         'go',
       ],
       matchDepNames: [
-        '*opentelemetry*',
+        'go.opentelemetry.io/*',
+        'github.com/open-telemetry/*'
       ],
       matchCategories: [
         'golang',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,39 +5,13 @@
     'helpers:pinGitHubActionDigestsToSemver',
     ':separateMultipleMajorReleases',
   ],
+  prHourlyLimit: 10,
   packageRules: [
     {
       matchFileNames: [
         '**/tests/**',
       ],
       enabled: true,
-    },
-    {
-      groupName: 'opentelemetry-deps-dotnet',
-      labels: [
-        'dotnet'
-      ],
-      matchDepNames: [
-        'OpenTelemetry.*'
-      ],
-      matchCategories: [
-        'dotnet'
-      ],
-      schedule: [
-        'before 8am on Monday'
-      ],
-    },
-    {
-      groupName: 'dotnet-other',
-      labels: [
-        'dotnet'
-      ],
-      matchCategories: [
-        'dotnet'
-      ],
-      schedule: [
-        'before 8am on Monday'
-      ],
     },
     {
       groupName: 'opentelemetry-deps-collector',
@@ -65,6 +39,33 @@
       ],
       schedule: [
         'before 8am on Monday',
+      ],
+    },
+    {
+      groupName: 'opentelemetry-deps-dotnet',
+      labels: [
+        'dotnet'
+      ],
+      matchDepNames: [
+        'OpenTelemetry.*'
+      ],
+      matchCategories: [
+        'dotnet'
+      ],
+      schedule: [
+        'before 8am on Monday'
+      ],
+    },
+    {
+      groupName: 'dotnet-other',
+      labels: [
+        'dotnet'
+      ],
+      matchCategories: [
+        'dotnet'
+      ],
+      schedule: [
+        'before 8am on Monday'
       ],
     },
     {
@@ -182,6 +183,18 @@
       ],
       matchManagers: [
         'github-actions',
+      ],
+      schedule: [
+        'before 8am on Monday',
+      ],
+    },
+    {
+      groupName: 'terraform',
+      labels: [
+        'terraform',
+      ],
+      matchManagers: [
+        'terraform',
       ],
       schedule: [
         'before 8am on Monday',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -194,8 +194,8 @@
     ],
   },
   semanticCommits: 'enabled',
-  semanticCommitType: "build",
-  semanticCommitScope: "deps",
+  semanticCommitType: 'build',
+  semanticCommitScope: 'deps',
   labels: [
     'dependencies',
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,13 +40,17 @@
       groupName: "opentelemetry-deps-nodejs",
       labels: ["javascript"],
       matchDepNames: ["@opentelemetry/*"],
-      matchCategories: ["node"],
+      matchCategories: [
+        'js'
+      ],
       schedule: ["before 8am on Monday"],
     },
     {
       groupName: "nodejs-other",
       labels: ["javascript"],
-      matchCategories: ["node"],
+      matchCategories: [
+        'js'
+      ],
       schedule: ["before 8am on Monday"],
     },
     {


### PR DESCRIPTION
Change matchCategories from 'node' to 'js' to ensure npm updates are grouped.

Add a dotnet group