### PR TITLE
chore: Make renovate behave more like dependabot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -116,7 +116,7 @@
     },
     {
       groupName: 'opentelemetry-deps-dotnet',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchDepNames: [
@@ -131,7 +131,7 @@
     },
     {
       groupName: 'java-other',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchCategories: [
@@ -143,7 +143,7 @@
     },
     {
       groupName: 'opentelemetry-deps-java',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchDepNames: [
@@ -158,7 +158,7 @@
     },
     {
       groupName: 'nodejs-other',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchCategories: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,7 +76,7 @@
     },
     {
       groupName: 'collector-other',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchCategories: [
@@ -88,7 +88,7 @@
     },
     {
       groupName: 'opentelemetry-deps-collector',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchPackageNames: [
@@ -104,7 +104,7 @@
     },
     {
       groupName: 'dotnet-other',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchCategories: [
@@ -170,7 +170,7 @@
     },
     {
       groupName: 'opentelemetry-deps-nodejs',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchDepNames: [
@@ -185,7 +185,7 @@
     },
     {
       groupName: 'python-other',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchCategories: [
@@ -197,7 +197,7 @@
     },
     {
       groupName: 'opentelemetry-deps-python',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchDepNames: [
@@ -212,7 +212,7 @@
     },
     {
       groupName: 'ruby-other',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchCategories: [
@@ -224,7 +224,7 @@
     },
     {
       groupName: 'opentelemetry-deps-ruby',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchDepNames: [
@@ -239,7 +239,7 @@
     },
     {
       groupName: 'actions',
-      updateTypes: [
+      matchUpdateTypes: [
         '!major'
       ],
       matchManagers: [
@@ -250,7 +250,7 @@
       ],
     },
     {
-      updateTypes: [
+      matchUpdateTypes: [
         'major'
       ],
       matchManagers: [
@@ -273,7 +273,7 @@
       ],
     },
     {
-      updateTypes: [
+      matchUpdateTypes: [
         'major'
       ],
       "dependencyDashboardApproval": true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,8 @@
     'helpers:pinGitHubActionDigestsToSemver',
     ':separateMultipleMajorReleases',
   ],
-  prHourlyLimit: 10,
+  prHourlyLimit: 15,
+  prConcurrentLimit: 15,
   ignorePaths: [
     "!**/tests/**"
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,6 +69,7 @@
       labels: [
         'github_actions',
       ],
+      semanticCommitType: 'build',
       matchManagers: [
         'github-actions',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,33 +6,76 @@
     ':separateMultipleMajorReleases',
   ],
   prHourlyLimit: 10,
+  ignorePaths: [
+    "!**/tests/**"
+  ],
   packageRules: [
     {
-      matchFileNames: [
-        '**/tests/**',
-      ],
-      enabled: true,
-    },
-    {
-      groupName: 'opentelemetry-deps-collector',
       labels: [
         'go',
       ],
-      matchDepNames: [
-        'go.opentelemetry.io/*',
-        'github.com/open-telemetry/*'
-      ],
+      semanticCommitType: 'build',
       matchCategories: [
         'golang',
       ],
-      schedule: [
-        'before 8am on Monday',
+    },
+    {
+      labels: [
+        'dotnet'
+      ],
+      semanticCommitType: 'build',
+      matchCategories: [
+        'dotnet'
+      ],
+    },
+    {
+      labels: [
+        'java',
+      ],
+      semanticCommitType: 'build',
+      matchCategories: [
+        'java',
+      ],
+    },
+    {
+      labels: [
+        'javascript',
+      ],
+      semanticCommitType: 'build',
+      matchCategories: [
+        'js',
+      ],
+    },
+    {
+      labels: [
+        'python',
+      ],
+      semanticCommitType: 'build',
+      matchCategories: [
+        'python',
+      ],
+    },
+    {
+      labels: [
+        'ruby',
+      ],
+      semanticCommitType: 'build',
+      matchCategories: [
+        'ruby',
+      ],
+    },
+    {
+      labels: [
+        'github_actions',
+      ],
+      matchManagers: [
+        'github-actions',
       ],
     },
     {
       groupName: 'collector-other',
-      labels: [
-        'go',
+      updateTypes: [
+        '!major'
       ],
       matchCategories: [
         'golang',
@@ -42,24 +85,25 @@
       ],
     },
     {
-      groupName: 'opentelemetry-deps-dotnet',
-      labels: [
-        'dotnet'
+      groupName: 'opentelemetry-deps-collector',
+      updateTypes: [
+        '!major'
       ],
-      matchDepNames: [
-        'OpenTelemetry.*'
+      matchPackageNames: [
+        'go.opentelemetry.io{/,}**',
+        'github.com/open-telemetry{/,}**'
       ],
       matchCategories: [
-        'dotnet'
+        'golang',
       ],
       schedule: [
-        'before 8am on Monday'
+        'before 8am on Monday',
       ],
     },
     {
       groupName: 'dotnet-other',
-      labels: [
-        'dotnet'
+      updateTypes: [
+        '!major'
       ],
       matchCategories: [
         'dotnet'
@@ -69,24 +113,24 @@
       ],
     },
     {
-      groupName: 'opentelemetry-deps-java',
-      labels: [
-        'java',
+      groupName: 'opentelemetry-deps-dotnet',
+      updateTypes: [
+        '!major'
       ],
       matchDepNames: [
-        'io.opentelemetry.*',
+        'OpenTelemetry.**'
       ],
       matchCategories: [
-        'java',
+        'dotnet'
       ],
       schedule: [
-        'before 8am on Monday',
+        'before 8am on Monday'
       ],
     },
     {
       groupName: 'java-other',
-      labels: [
-        'java',
+      updateTypes: [
+        '!major'
       ],
       matchCategories: [
         'java',
@@ -96,15 +140,15 @@
       ],
     },
     {
-      groupName: 'opentelemetry-deps-nodejs',
-      labels: [
-        'javascript',
+      groupName: 'opentelemetry-deps-java',
+      updateTypes: [
+        '!major'
       ],
       matchDepNames: [
-        '@opentelemetry/*',
+        'io.opentelemetry.**',
       ],
       matchCategories: [
-        'js',
+        'java',
       ],
       schedule: [
         'before 8am on Monday',
@@ -112,8 +156,8 @@
     },
     {
       groupName: 'nodejs-other',
-      labels: [
-        'javascript',
+      updateTypes: [
+        '!major'
       ],
       matchCategories: [
         'js',
@@ -123,15 +167,15 @@
       ],
     },
     {
-      groupName: 'opentelemetry-deps-python',
-      labels: [
-        'python',
+      groupName: 'opentelemetry-deps-nodejs',
+      updateTypes: [
+        '!major'
       ],
       matchDepNames: [
-        'opentelemetry-*',
+        '@opentelemetry/**',
       ],
       matchCategories: [
-        'python',
+        'js',
       ],
       schedule: [
         'before 8am on Monday',
@@ -139,8 +183,8 @@
     },
     {
       groupName: 'python-other',
-      labels: [
-        'python',
+      updateTypes: [
+        '!major'
       ],
       matchCategories: [
         'python',
@@ -150,15 +194,15 @@
       ],
     },
     {
-      groupName: 'opentelemetry-deps-ruby',
-      labels: [
-        'ruby',
+      groupName: 'opentelemetry-deps-python',
+      updateTypes: [
+        '!major'
       ],
       matchDepNames: [
-        'opentelemetry-*',
+        'opentelemetry-**',
       ],
       matchCategories: [
-        'ruby',
+        'python',
       ],
       schedule: [
         'before 8am on Monday',
@@ -166,8 +210,23 @@
     },
     {
       groupName: 'ruby-other',
-      labels: [
+      updateTypes: [
+        '!major'
+      ],
+      matchCategories: [
         'ruby',
+      ],
+      schedule: [
+        'before 8am on Monday',
+      ],
+    },
+    {
+      groupName: 'opentelemetry-deps-ruby',
+      updateTypes: [
+        '!major'
+      ],
+      matchDepNames: [
+        'opentelemetry-**',
       ],
       matchCategories: [
         'ruby',
@@ -178,8 +237,19 @@
     },
     {
       groupName: 'actions',
-      labels: [
-        'github_actions',
+      updateTypes: [
+        '!major'
+      ],
+      matchManagers: [
+        'github-actions',
+      ],
+      schedule: [
+        'before 8am on Monday',
+      ],
+    },
+    {
+      updateTypes: [
+        'major'
       ],
       matchManagers: [
         'github-actions',
@@ -199,6 +269,12 @@
       schedule: [
         'before 8am on Monday',
       ],
+    },
+    {
+      updateTypes: [
+        'major'
+      ],
+      "dependencyDashboardApproval": true,
     },
   ],
   lockFileMaintenance: {


### PR DESCRIPTION
This has been tested to resolve the following issues:
- incorrect grouping of otel dependencies - resolved by changing order & match pattern
- Not updating tests directory - adjustment to the ignore paths


Partially test to resolve
- incorrect pr titles - review of logs showed title changing due to adding scope to label rule but not all pr combinations tested

this also seperates major updates from other groups & adds approval to avoid accidentally merging major bump as well as enable to delay them till after minor etc. We can certainly change this rule.