### PR TITLE
chore: Fix ignorePaths in renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,13 @@
   prHourlyLimit: 15,
   prConcurrentLimit: 15,
   ignorePaths: [
-    "!**/tests/**"
+    // re‑declare everything best-practices ignores
+    "**/vendor/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/coverage/**",
+    "**/node_modules/**",
+    "**/.cache/**",
   ],
   packageRules: [
     {


### PR DESCRIPTION
Added additional paths to ignore for Renovate.