### PR TITLE
chore: Further refinement of renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -262,6 +262,7 @@
       matchManagers: [
         'github-actions',
       ],
+      semanticCommitType: 'build',
       schedule: [
         'before 8am on Monday',
       ],
@@ -274,6 +275,7 @@
       matchManagers: [
         'terraform',
       ],
+      semanticCommitType: 'build',
       schedule: [
         'before 8am on Monday',
       ],
@@ -281,6 +283,9 @@
     {
       matchUpdateTypes: [
         'major'
+      ],
+      matchManagers: [
+        '!github-actions',
       ],
       "dependencyDashboardApproval": true,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -296,6 +296,9 @@
       'before 8am on Wednesday',
     ],
   },
+  postUpdateOptions: [
+		"gomodTidy"
+	],
   semanticCommits: 'enabled',
   semanticCommitType: 'build',
   semanticCommitScope: 'deps',


### PR DESCRIPTION
This ensures the commit type is set as expected for gh actions & terraform.

This also removals approvals from major gh actions.

Run gomodtidy after updates as done in collector to resolve build issues aka https://github.com/open-telemetry/opentelemetry-lambda/pull/2369