### PR TITLE
chore: group docker updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -268,6 +268,19 @@
       ],
     },
     {
+      groupName: 'docker',
+      labels: [
+        'docker',
+      ],
+      matchManagers: [
+        'docker',
+      ],
+      semanticCommitType: 'build',
+      schedule: [
+        'before 8am on Monday',
+      ],
+    },
+    {
       groupName: 'terraform',
       labels: [
         'terraform',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -272,7 +272,7 @@
       labels: [
         'docker',
       ],
-      matchManagers: [
+      matchCategories: [
         'docker',
       ],
       semanticCommitType: 'build',
@@ -285,7 +285,7 @@
       labels: [
         'terraform',
       ],
-      matchManagers: [
+      matchCategories: [
         'terraform',
       ],
       semanticCommitType: 'build',

--- a/ruby/src/otel/Dockerfile
+++ b/ruby/src/otel/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
 
 RUN mkdir /build
 


### PR DESCRIPTION
This groups docker updates and sets the expected commit type.

note the docker dependency has also been pinned.