### PR TITLE
chore: Add gomodTidy to postUpdateOptions in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,6 +95,9 @@
       matchCategories: [
         'golang',
       ],
+      postUpdateOptions: [
+		'gomodTidy',
+	  ],
       schedule: [
         'before 8am on Monday',
       ],
@@ -111,6 +114,9 @@
       matchCategories: [
         'golang',
       ],
+      postUpdateOptions: [
+		'gomodTidy',
+	  ],
       schedule: [
         'before 8am on Monday',
       ],
@@ -319,8 +325,8 @@
     ],
   },
   postUpdateOptions: [
-		"gomodTidy"
-	],
+	'gomodTidy',
+  ],
   semanticCommits: 'enabled',
   semanticCommitType: 'build',
   semanticCommitScope: 'deps',


### PR DESCRIPTION
We are currently having an issue where gomodtidy is not running on pr's which is causing pr's aka https://github.com/open-telemetry/opentelemetry-lambda/pull/2394 to fail ci checks. The hope is that will address that.

Note collector also a custom ci step to add additional commit but hope is to avoid That.