### PR TITLE
chore: Bump unstable

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -143,6 +143,18 @@
       ],
     },
     {
+      matchPackageNames: [
+        'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha',
+        'io.opentelemetry.contrib:opentelemetry-aws-resources',
+      ],
+      // Renovate's default behavior is only to update from unstable -> unstable if it's for the
+      // major.minor.patch, under the assumption that you would want to update to the stable version
+      // of that release instead of the unstable version for a future release (but there's never any
+      // stable version of opentelemetry-instrumentation-bom-alpha so this logic doesn't apply
+      ignoreUnstable: false,
+      allowedVersions: '!/\\-SNAPSHOT$/'
+    },
+    {
       groupName: 'java-other',
       matchUpdateTypes: [
         '!major'


### PR DESCRIPTION
This allows bumps of the specified unstable packages to the next unstable regardless of new version (major, minor or patch).

Package rule has been copied from otel-android where it is working.