### PR TITLE
ci: Allow major golang requires

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -333,6 +333,9 @@
       matchUpdateTypes: [
         'major'
       ],
+      matchDepTypes: [
+        '!require',
+      ],
       matchManagers: [
         '!github-actions',
       ],


### PR DESCRIPTION
This removes approval being required for the go dependency updates.