### PR TITLE
ci: Golang indirect updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -337,6 +337,20 @@
       ],
       "dependencyDashboardApproval": true,
     },
+    {
+      groupName: "Lock file maintenance golang",
+      matchDepTypes: ["indirect"],
+      matchCategories: [
+        'golang',
+      ],
+      enabled: true,
+      schedule: [
+        'before 8am on Wednesday',
+      ],
+      postUpdateOptions: [
+        'gomodTidy',
+      ],
+    }
   ],
   lockFileMaintenance: {
     enabled: true,


### PR DESCRIPTION
This performs indirect updates once per week like we do with other lock files. Note this resolves the difference we are seeing in renovate vs dependabot but works for other indirect updates.