### PR TITLE
chore: Renovate lint

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -342,6 +342,7 @@
   lockFileMaintenance: {
     enabled: true,
     commitMessageAction: "Lock file maintenance {{categories}}",
+    branchTopic: "lock-file-maintenance-{{categories}}",
     schedule: [
       'before 8am on Wednesday',
     ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -103,8 +103,8 @@
         'golang',
       ],
       postUpdateOptions: [
-		'gomodTidy',
-	  ],
+        'gomodTidy',
+      ],
       schedule: [
         'before 8am on Monday',
       ],
@@ -122,8 +122,8 @@
         'golang',
       ],
       postUpdateOptions: [
-		'gomodTidy',
-	  ],
+        'gomodTidy',
+      ],
       schedule: [
         'before 8am on Monday',
       ],
@@ -284,6 +284,7 @@
       matchManagers: [
         'github-actions',
       ],
+      semanticCommitType: 'build',
       schedule: [
         'before 8am on Monday',
       ],
@@ -340,12 +341,13 @@
   ],
   lockFileMaintenance: {
     enabled: true,
+    commitMessageAction: "Lock file maintenance {{categories}}",
     schedule: [
       'before 8am on Wednesday',
     ],
   },
   postUpdateOptions: [
-	'gomodTidy',
+    'gomodTidy',
   ],
   semanticCommits: 'enabled',
   semanticCommitType: 'build',


### PR DESCRIPTION
This fixes tabs vs spaces in renovate config.

Also adds categories to the lockfile tasks so that we can see what category it refers to.