### PR TITLE
ci: Auto label pr's

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,46 @@
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "integration-tests/**"
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/Dockerfile"
+documentations:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs"
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "collector/**"
+          - "go/**"
+java:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "java/**"
+          - "integration-tests/**/java/**"
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "nodejs/**"
+          - "integration-tests/**/nodejs/**"
+.NET:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "dotnet/**"
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "python/**"
+          - "integration-tests/**/python/**"
+ruby:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "ruby/**"
+          - "integration-tests/**/ruby/**"
+terraform:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.tf"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,62 +25,13 @@
   ],
   packageRules: [
     {
-      labels: [
-        'dependencies',
-        'go',
-      ],
       semanticCommitType: 'build',
       matchCategories: [
+        'dotnet',
         'golang',
-      ],
-    },
-    {
-      labels: [
-        'dependencies',
-        'dotnet'
-      ],
-      semanticCommitType: 'build',
-      matchCategories: [
-        'dotnet'
-      ],
-    },
-    {
-      labels: [
-        'dependencies',
         'java',
-      ],
-      semanticCommitType: 'build',
-      matchCategories: [
-        'java',
-      ],
-    },
-    {
-      labels: [
-        'dependencies',
-        'javascript',
-      ],
-      semanticCommitType: 'build',
-      matchCategories: [
         'js',
-      ],
-    },
-    {
-      labels: [
-        'dependencies',
         'python',
-      ],
-      semanticCommitType: 'build',
-      matchCategories: [
-        'python',
-      ],
-    },
-    {
-      labels: [
-        'dependencies',
-        'ruby',
-      ],
-      semanticCommitType: 'build',
-      matchCategories: [
         'ruby',
       ],
     },
@@ -302,10 +253,6 @@
     },
     {
       groupName: 'docker',
-      labels: [
-        'dependencies',
-        'docker',
-      ],
       matchCategories: [
         'docker',
       ],
@@ -316,10 +263,6 @@
     },
     {
       groupName: 'terraform',
-      labels: [
-        'dependencies',
-        'terraform',
-      ],
       matchCategories: [
         'terraform',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -226,8 +226,7 @@
         'github-actions',
       ],
       semanticCommitType: 'build',
-      labels: [
-        'dependencies',
+      addLabels: [
         'github_actions',
       ],
       schedule: [
@@ -242,8 +241,7 @@
         'github-actions',
       ],
       semanticCommitType: 'build',
-      labels: [
-        'dependencies',
+      addLabels: [
         'github_actions',
       ],
       schedule: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,16 +36,6 @@
       ],
     },
     {
-      labels: [
-        'dependencies',
-        'github_actions',
-      ],
-      semanticCommitType: 'build',
-      matchManagers: [
-        'github-actions',
-      ],
-    },
-    {
       groupName: 'collector-other',
       matchUpdateTypes: [
         '!major'
@@ -235,6 +225,11 @@
       matchManagers: [
         'github-actions',
       ],
+      semanticCommitType: 'build',
+      labels: [
+        'dependencies',
+        'github_actions',
+      ],
       schedule: [
         'before 8am on Monday',
       ],
@@ -247,6 +242,10 @@
         'github-actions',
       ],
       semanticCommitType: 'build',
+      labels: [
+        'dependencies',
+        'github_actions',
+      ],
       schedule: [
         'before 8am on Monday',
       ],

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write # required for adding labels to pr
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,0 +1,23 @@
+name: Check PR
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    name: Labels
+    permissions:
+      issues: write # required for creating labels
+      pull-requests: write # required for adding labels to pr
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
This moves labeling out of renovate and into a dedicated workflow. This enables all pr's to be auto labeled and further simplifies renovate rules.