### PR TITLE
ci: Change check-links trigger & fallback

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/check-links.yaml"
+      - ".github/lychee.toml"
       - "**/*.md"
 
 concurrency:
@@ -31,7 +32,7 @@ jobs:
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)
 
-          if [ -z "$files" ] && git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep -q ".github/workflows/check-links.yaml"; then
+          if [ -z "$files" ] then
             files="**/*.md"
           fi
 

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)
 
-          if [ -z "$files" ] then
+          if [ -z "$files" ]; then
             files="**/*.md"
           fi
 

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - ".github/workflows/check-links.yaml"
+      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -28,7 +31,7 @@ jobs:
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)
 
-          if [ -z "$files" ] && git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep -q "package.json"; then
+          if [ -z "$files" ] && git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep -q ".github/workflows/check-links.yaml"; then
             files="**/*.md"
           fi
 


### PR DESCRIPTION
This changes it to only fallback to an entire repo link check when the workflow has been triggered based on paths filter.

Also adjusted pr trigger to filter based on file paths to reduce triggers.