### PR TITLE
ci: Fix lychee config

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,4 +1,4 @@
-include_fragments = true
+include_fragments = "full"
 
 accept = ["200..=299", "429"]
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These 2 layers are meant to be used in conjunction to instrument your lambda fun
 
 * **What exporters/receivers/processors are included from the OpenTelemetry Collector?**
     > You can check out [the stripped-down collector's imports](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/lambdacomponents/default.go) in this repository for a full list of currently included components.
-
+    >
     > Self-built binaries of the collector have **experimental** support for a custom set of connectors/exporters/receivers/processors. For more information, see [(Experimental) Customized collector build](./collector/README.md#experimental-customized-collector-build)
 * **Is the Lambda layer provided or do I need to build it and distribute it myself?**
     > This repository provides pre-built Lambda layers, their ARNs are available in the [Releases](https://github.com/open-telemetry/opentelemetry-lambda/releases). You can also build the layers manually and publish them in your AWS account. This repo has files to facilitate doing that. More information is provided in [the Collector folder's README](collector/README.md).


### PR DESCRIPTION
This fixes the invalid lychee config by copying the offending setting from otel.io.