### PR TITLE
Enhance Renovate workflow with app token creation

### DIFF
--- a/.github/workflows/renovate-go.yml
+++ b/.github/workflows/renovate-go.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.OTELBOT_FAAS_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_FAAS_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_LAMBDA_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_LAMBDA_PRIVATE_KEY }}
           permission-contents: write
       - name: Fork checkout
         if: ${{ github.event.pull_request.head.repo.fork == false }}

--- a/.github/workflows/renovate-go.yml
+++ b/.github/workflows/renovate-go.yml
@@ -18,10 +18,27 @@ jobs:
     if: startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Create otelbot app token
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.OTELBOT_FAAS_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_FAAS_PRIVATE_KEY }}
+          permission-contents: write
+      - name: Fork checkout
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          # zizmor: ignore[artipacked] Credentials are required by the Renovate branch push below.
+          persist-credentials: true
+      - name: Local checkout
+        if: ${{ github.event.pull_request.head.repo.fork == true }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: collector/go.mod

--- a/.github/workflows/renovate-go.yml
+++ b/.github/workflows/renovate-go.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Commit and push changes
         if: steps.check_changes.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name otelbot[bot]
+          git config user.email 197425009+otelbot[bot]@users.noreply.github.com
           git add collector/
           if git diff --staged --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
Added steps to create GitHub app token for non-fork PRs and updated token usage in checkout step.

This is to eliminate the need to be manually approving the ci run after the go mod tidy command has run.

The bot setup has been requested via https://github.com/open-telemetry/community/issues/3631