### PR TITLE
fix(dotnet): target net8.0 so the wrapper sample emits spans

### DIFF
--- a/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -5,7 +5,7 @@ module "hello-lambda-function" {
   architectures = compact([var.architecture])
   function_name = var.name
   handler       = "AwsSdkSample::AwsSdkSample.Function::TracingFunctionHandler"
-  runtime       = "dotnet6"
+  runtime       = "dotnet8"
 
   create_package         = false
   local_existing_package = "${path.module}/../../wrapper/SampleApps/build/function.zip"

--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 

--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
@@ -18,7 +18,7 @@ mkdir -p build/dotnet
 dotnet publish \
     --output "./build/dotnet" \
     --configuration "Release" \
-    --framework "net6.0" /p:GenerateRuntimeConfigurationFiles=true \
+    --framework "net8.0" /p:GenerateRuntimeConfigurationFiles=true \
     --runtime linux-$DOTNET_LINUX_ARCH \
     --self-contained false
 cd build/dotnet


### PR DESCRIPTION
The dotnet `aws-sdk/wrapper` integration test was failing because the trace contained only Lambda's passive Active-tracing segments; the instrumented handler span and downstream S3 span never reached X-Ray.

## Changes
- Retarget the `aws-sdk` sample to **net8.0** (the `dotnet6` Lambda runtime is deprecated) in the `.csproj`, `build.sh`, and Terraform `main.tf`.

## Testing
Files affected are limited to `dotnet/sample-apps/aws-sdk/`.