### PR TITLE
chore: Renovate tweaks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -162,6 +162,15 @@
       dependencyDashboardApproval: true,
     },
     {
+      matchUpdateTypes: [
+        'major'
+      ],
+      matchDepNames: [
+        'node',
+      ],
+      dependencyDashboardApproval: true,
+    },
+    {
       matchManagers: [
         "gomod"
       ],
@@ -182,6 +191,7 @@
       enabled: true,
       separateMajorMinor: false,
       separateMultipleMajor: false,
+      abandonmentThreshold: "50 years",
       schedule: [
         'before 8am on Wednesday',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -191,6 +191,7 @@
       enabled: true,
       separateMajorMinor: false,
       separateMultipleMajor: false,
+      prBodyTemplate: "{{{header}}}{{{warnings}}}🔧 This Pull Request updates lock files to use the latest dependency versions.{{{notes}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
       abandonmentThreshold: "50 years",
       schedule: [
         'before 8am on Wednesday',


### PR DESCRIPTION
This cleans up the renovate dashboard by eliminating transitive dependencies from abandonment threshold as there is nothing we can do about them. 

The lockfile pr description is cleanup to improve readability.

Lastly major node updates now require approval.